### PR TITLE
Add error checking and status reporting to hadoop setup

### DIFF
--- a/lib/clouds/vcd_cloud_ops.py
+++ b/lib/clouds/vcd_cloud_ops.py
@@ -394,7 +394,7 @@ class VcdCmds(CommonCloudFunctions) :
         '''
         try :
             _status = 100
-            _fmsg = "An error has occurred, but no error message was captured"
+            _fmsg = "An error has occurred when creating new vApp, but no error message was captured"
             
             obj_attr_list["cloud_vm_uuid"] = "NA"
             _instance = False
@@ -426,7 +426,7 @@ class VcdCmds(CommonCloudFunctions) :
 
             obj_attr_list["last_known_state"] = "about to send create request"
 
-            _msg = "Starting an instance of image "
+            _msg = "Attempting to clone an instance of vApp "
             _msg += obj_attr_list["imageid1"]
             _msg += " on vCloud Director, creating a vm named "
             _msg += obj_attr_list["cloud_vm_name"]
@@ -435,7 +435,7 @@ class VcdCmds(CommonCloudFunctions) :
             # I can't get libcloud's driver.list_images() function to work, so I'm not sure how to create a new image object
             # based on an image.  The vCloud Director system I use doesn't have an appropriate stock image that will work with
             # cloudbench.  So, I'll instead clone an instantiated image that I've created.
-            _msg = "Looking for an existing vApp named "
+            _msg = "...Looking for an existing vApp named "
             _msg += obj_attr_list["imageid1"]
             cbdebug(_msg, True)
 
@@ -443,13 +443,13 @@ class VcdCmds(CommonCloudFunctions) :
             # Daniel 9/6/2013 Need to error check the response to ex_find_node and throw exception if no image found
  
             vm_computername = "vm" + obj_attr_list["name"].split("_")[1]
-            _msg = "Launching new VM with hostname " + vm_computername
-            cbdebug(_msg)
+            _msg = "...Launching new vApp containing VM with hostname " + vm_computername
+            cbdebug(_msg,True)
             _reservation = self.vcdconn.create_node(name = obj_attr_list["cloud_vm_name"], image = image_to_clone, ex_vm_names = [vm_computername])
 
             obj_attr_list["last_known_state"] = "sent create request to vCloud Director, parsing response"
 
-            _msg = "Sent command to create node, waiting for creation..."
+            _msg = "...Sent command to create node, waiting for creation..."
             cbdebug(_msg)
 
             if _reservation :
@@ -463,8 +463,8 @@ class VcdCmds(CommonCloudFunctions) :
                 obj_attr_list["cloud_vm_uuid"] = _reservation.uuid
                 obj_attr_list["instance_obj"] = _reservation
 
-                _msg = "New instance UUID is " + _reservation.uuid
-                cbdebug(_msg)
+                _msg = "...Success. New instance UUID is " + _reservation.uuid
+                cbdebug(_msg,True)
 
                 self.take_action_if_requested("VM", obj_attr_list, "provision_started")
 
@@ -478,7 +478,7 @@ class VcdCmds(CommonCloudFunctions) :
                 _status = 0
 
             else :
-                _fmsg = "Failed to obtain instance's (cloud-assigned) uuid. The "
+                _fmsg = "...Failed to obtain instance's (cloud-assigned) uuid. The "
                 _fmsg += "instance creation failed for some unknown reason."
                 cberr(_fmsg)
                 _status = 100

--- a/scripts/hadoop/cb_config_hadoop_cluster.sh
+++ b/scripts/hadoop/cb_config_hadoop_cluster.sh
@@ -21,46 +21,89 @@ source $(echo $0 | sed -e "s/\(.*\/\)*.*/\1.\//g")/cb_hadoop_common.sh
 #####################################################################################
 # Hadoop cluster preparation
 # - Editing configuration files
-# - Just before formatting namenode, starting masters and slaves
 #####################################################################################
 
 #####################################################################################
-#Current logic works under the assumption that 
-#   1. there is only one master vm which serves as a NameNode and a JobTracker, 
-#      and never works as a slave (meaning DataNode, TaskTracker).
-#   2. there is at least one slave machine which is physically different from
+# Assumptions: 
+#   1. There is only one master VM which serves as a NameNode and a 
+#      Jobtracker / Resource Manager, and is not also a slave (meaning DataNode, TaskTracker).
+#   2. There is at least one slave VM which is a different machine from
 #       master vm.
 #####################################################################################
 
-syslog_netcat "hadoop_master_ip: $hadoop_master_ip"
-syslog_netcat "..my_ip=$my_ip_addr .."
-hadoop_version_string=`$HADOOP_HOME/bin/hadoop version | sed '1!d'`
-syslog_netcat "..Hadoop Version is $hadoop_version_string .."
+syslog_netcat "Updating local Hadoop cluster configuration files..."
 
-is_preferIPv4Stack=`cat ${HADOOP_CONF_DIR}/hadoop-env.sh | grep -c "preferIPv4Stack=true"`
-if [ ${is_preferIPv4Stack} -eq 0 ]
-then
-	syslog_netcat "Adding extra options to hadoop-env.sh to ignore IPv6 addresses"
-	echo "export HADOOP_OPTS=-Djava.net.preferIPv4Stack=true" >> $HADOOP_CONF_DIR/hadoop-env.sh
-	echo "export JAVA_HOME=${JAVA_HOME}" >> $HADOOP_CONF_DIR/hadoop-env.sh
-fi
+hadoop_version_string=`$HADOOP_HOME/bin/hadoop version | sed '1!d'`
+syslog_netcat "Hadoop home directory is ${HADOOP_HOME}"
+syslog_netcat "Hadoop version is $hadoop_version_string"
+syslog_netcat "Hadoop configuration directory is ${HADOOP_CONF_DIR}"
 
 DFS_NAME_DIR=`get_my_ai_attribute_with_default dfs_name_dir /tmp/cbhadoopname`
 eval DFS_NAME_DIR=${DFS_NAME_DIR}
+syslog_netcat "Local directory for Hadoop namenode is ${DFS_NAME_DIR}"
 
 DFS_DATA_DIR=`get_my_ai_attribute_with_default dfs_data_dir /tmp/cbhadoopdata`
 eval DFS_DATA_DIR=${DFS_DATA_DIR}
+syslog_netcat "Local directory for Hadoop datanode is ${DFS_NAME_DIR}"
+
+if [ ${hadoop_use_yarn} -eq 1 ] ; then
+	syslog_netcat "Hadoop will be configured to use MRv2 (YARN)"
+else
+	syslog_netcat "Hadoop will be configured to use MRv1"
+fi
 
 ###################################################################
-# Set up masters/slaves files in the hadoop master vm
+# Verify current user has write access to Hadoop configuration directory
 ###################################################################
 
-syslog_netcat "..Updating masters/slaves files in ${HADOOP_CONF_DIR}..."
+echo "Test" > $HADOOP_CONF_DIR/test
+if [ $? -eq 0 ]; then
+	rm $HADOOP_CONF_DIR/test
+else
+	syslog_netcat "Error: User $(whoami) unable to write to Hadoop configuration directory ${HADOOP_CONF_DIR} - NOK"
+        exit 1
+fi
+
+###################################################################
+# Disable IPv6 use by Hadoop
+###################################################################
+
+if [ -e ${HADOOP_CONF_DIR}/hadoop-env.sh ]; then
+	is_preferIPv4Stack=`cat ${HADOOP_CONF_DIR}/hadoop-env.sh | grep -c "preferIPv4Stack=true"`
+	if [ ${is_preferIPv4Stack} -eq 0 ]; then
+		syslog_netcat "Adding extra options to existing hadoop-env.sh to ignore IPv6 addresses"
+		echo "export HADOOP_OPTS=-Djava.net.preferIPv4Stack=true" >> $HADOOP_CONF_DIR/hadoop-env.sh
+		echo "export JAVA_HOME=${JAVA_HOME}" >> $HADOOP_CONF_DIR/hadoop-env.sh
+	fi
+else
+	syslog_netcat "Creating hadoop-env.sh file with options to ignore IPv6 addresses"
+	echo "export HADOOP_OPTS=-Djava.net.preferIPv4Stack=true" > $HADOOP_CONF_DIR/hadoop-env.sh
+	echo "export JAVA_HOME=${JAVA_HOME}" >> $HADOOP_CONF_DIR/hadoop-env.sh
+fi
+
+###################################################################
+# Set up masters and slaves files
+###################################################################
+
+syslog_netcat "Updating masters, slaves files in ${HADOOP_CONF_DIR}..."
 echo "${hadoop_master_ip}" > $HADOOP_CONF_DIR/masters
-echo "${slave_ips}" > $HADOOP_CONF_DIR/slaves
-syslog_netcat "....Done...."
+if [ $? -ne 0 ]; then
+   syslog_netcat "Error creating $HADOOP_CONF_DIR/masters - NOK"
+   exit 1
+fi
 
-syslog_netcat "..Creating files core-site.xml, hdfs-site.xml and mapred-site.xml in ${HADOOP_CONF_DIR}..."
+echo "${slave_ips}" > $HADOOP_CONF_DIR/slaves
+if [ $? -ne 0 ]; then
+   syslog_netcat "Error creating $HADOOP_CONF_DIR/slavess - NOK"
+   exit 1
+fi
+syslog_netcat "...masters, slaves files updated."
+
+###################################################################
+# Create core-site.xml, hdfs-site.xml, and mapred-site.xml files
+###################################################################
+
+syslog_netcat "Creating files core-site.xml, hdfs-site.xml and mapred-site.xml..."
 cat << EOF > $HADOOP_CONF_DIR/core-site.xml
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
@@ -71,13 +114,17 @@ cat << EOF > $HADOOP_CONF_DIR/core-site.xml
 <property>
 <name>fs.default.name</name>
 <value>hdfs://HADOOP_NAMENODE_IP:9000</value>
-<description>The name of the default file system. Either the
-literal string "local" or a host:port for NDFS.
-</description>
 <final>true</final>
 </property>
 </configuration>
 EOF
+if [ $? -ne 0 ]; then
+   syslog_netcat "Error creating core-site.xml - NOK"
+   exit 1
+else
+   echo "...core-site.xml successfully created."
+fi
+
 
 if [ ${hadoop_use_yarn} -eq 1 ] ; then
 	cat << EOF > $HADOOP_CONF_DIR/mapred-site.xml
@@ -101,6 +148,13 @@ if [ ${hadoop_use_yarn} -eq 1 ] ; then
 </configuration>
 EOF
 
+	if [ $? -ne 0 ]; then
+	   syslog_netcat "Error creating mapred-site.xml - NOK"
+	   exit 1
+	else
+	   echo "...mapred-site.xml successfully created."
+	fi
+
 else
 	cat << EOF > $HADOOP_CONF_DIR/mapred-site.xml
 <?xml version="1.0"?>
@@ -116,8 +170,14 @@ else
 </property>
 </configuration>
 EOF
-fi
 
+	if [ $? -ne 0 ]; then
+	   syslog_netcat "Error creating mapred-site.xml - NOK"
+	   exit 1
+	else
+	   echo "...mapred-site.xml successfully created."
+	fi
+fi
 
 if [ ${hadoop_use_yarn} -eq 1 ] ; then
 	cat << EOF > $HADOOP_CONF_DIR/hdfs-site.xml
@@ -144,6 +204,13 @@ if [ ${hadoop_use_yarn} -eq 1 ] ; then
 </configuration>
 EOF
 
+	if [ $? -ne 0 ]; then
+	   syslog_netcat "Error creating hdfs-site.xml - NOK"
+	   exit 1
+	else
+	   echo "...hdfs-site.xml successfully created."
+	fi
+
 else
 	cat << EOF > $HADOOP_CONF_DIR/hdfs-site.xml
 <?xml version="1.0"?>
@@ -155,29 +222,27 @@ else
 <property>
 <name>dfs.name.dir</name>
 <value>DFS_NAME_DIR</value>
-<description>Determines where on the local filesystem the DFS name node
-should store the name table. If this is a comma-delimited list
-of directories then the name table is replicated in all of the
-directories, for redundancy. </description>
 <final>true</final>
 </property>
 
 <property>
 <name>dfs.data.dir</name>
 <value>DFS_DATA_DIR</value>
-<description>Determines where on the local filesystem an DFS data node
-should store its blocks. If this is a comma-delimited
-list of directories, then data will be stored in all named
-directories, typically on different devices.
-Directories that do not exist are ignored.
-</description>
 </property>
 </configuration>
 EOF
+
+	if [ $? -ne 0 ]; then
+	   syslog_netcat "Error creating hdfs-site.xml - NOK"
+	   exit 1
+	else
+	   echo "...hdfs-site.xml successfully created."
+	fi
+
 fi
 
 if [ ${hadoop_use_yarn} -eq 1 ] ; then
-	syslog_netcat "..Creating file yarn-site.xml in ${HADOOP_CONF_DIR}..."
+	syslog_netcat "Creating file yarn-site.xml..."
 
 	cat << EOF > $HADOOP_CONF_DIR/yarn-site.xml
 <?xml version="1.0"?>
@@ -218,47 +283,46 @@ if [ ${hadoop_use_yarn} -eq 1 ] ; then
 </configuration>
 EOF
 
+	if [ $? -ne 0 ]; then
+	   syslog_netcat "Error creating yarn-site.xml - NOK"
+	   exit 1
+	else
+	   echo "...yarn-site.xml successfully created."
+	fi
 fi
 
-syslog_netcat "....Done...."
-
 ###################################################################
-# Editing hadoop conf.xml files to add mandatory conf knobs. 
-#
-# NOTE: ONE PROBLEM: the input tmp conf files should also contain 
-#       the strings "HADDOP_NAMENODE_IP" and "HADOOP_JOBTRACKER_IP" !!!
-#       Now we have the fix: the name of the knob and its value
-#	can be defined in cb_hadoop_common.sh (see below). 
-#	But currently since the hadoop conf.xml files in the golden image
-#	are using have the following placeholders (HADOOP_NAMENODE_IP..),
-#	we stick to the following three seds.	
+# Updating hadoop config files to replace placeholders with actual values
 ###################################################################
 
-syslog_netcat "..Editing hadoop conf files"
-sed -i -e "s/HADOOP_NAMENODE_IP/${hadoop_master_ip}/g" $HADOOP_CONF_DIR/core-site.xml
-sed -i -e "s/HADOOP_JOBTRACKER_IP/${hadoop_master_ip}/g" $HADOOP_CONF_DIR/mapred-site.xml
-sed -i -e "s/NUM_REPLICA/1/g" $HADOOP_CONF_DIR/hdfs-site.xml #3 is default. 1 is given for sort's performance
+syslog_netcat "Updating placeholders in hadoop config files..."
+sudo sed -i -e "s/HADOOP_NAMENODE_IP/${hadoop_master_ip}/g" $HADOOP_CONF_DIR/core-site.xml
+sudo sed -i -e "s/HADOOP_JOBTRACKER_IP/${hadoop_master_ip}/g" $HADOOP_CONF_DIR/mapred-site.xml
+sudo sed -i -e "s/NUM_REPLICA/1/g" $HADOOP_CONF_DIR/hdfs-site.xml #3 is default. 1 is given for sort's performance
 
 if [ ${hadoop_use_yarn} -eq 1 ] ; then
-	sed -i -e "s/HADOOP_JOBTRACKER_IP/${hadoop_master_ip}/g" $HADOOP_CONF_DIR/yarn-site.xml
+	sudo sed -i -e "s/HADOOP_JOBTRACKER_IP/${hadoop_master_ip}/g" $HADOOP_CONF_DIR/yarn-site.xml
 fi
-
 
 TEMP_DFS_NAME_DIR=`echo ${DFS_NAME_DIR} | sed -e "s/\//-__-__/g"`
 TEMP_DFS_DATA_DIR=`echo ${DFS_DATA_DIR} | sed -e "s/\//-__-__/g"`
 
-sed -i -e "s/DFS_NAME_DIR/${TEMP_DFS_NAME_DIR}/g" $HADOOP_CONF_DIR/hdfs-site.xml
-sed -i -e "s/DFS_DATA_DIR/${TEMP_DFS_DATA_DIR}/g" $HADOOP_CONF_DIR/hdfs-site.xml
+sudo sed -i -e "s/DFS_NAME_DIR/${TEMP_DFS_NAME_DIR}/g" $HADOOP_CONF_DIR/hdfs-site.xml
+sudo sed -i -e "s/DFS_DATA_DIR/${TEMP_DFS_DATA_DIR}/g" $HADOOP_CONF_DIR/hdfs-site.xml
 
-sed -i -e "s/-__-__/\//g" $HADOOP_CONF_DIR/hdfs-site.xml
+sudo sed -i -e "s/-__-__/\//g" $HADOOP_CONF_DIR/hdfs-site.xml
+
+syslog_netcat "Placeholders updated."
 
 ###################################################################
 # Editing hadoop conf.xml files for the optional confs 
 # as defined in cb_hadoop_common.sh
 ###################################################################
+syslog_netcat "Applying any additional Hadoop parameters specified in cb_hadoop_common.sh..."
+
 #core-site.xml
 output_file=$HADOOP_CONF_DIR/core-site.xml
-sed -i -e "s/<\/configuration>//" $output_file
+sudo sed -i -e "s/<\/configuration>//" $output_file
 for k in "${!CORE_SITE_PROPERTIES[@]}"
 do
 	echo "<property>" >> $output_file
@@ -275,7 +339,7 @@ echo "</configuration>" >> $output_file
 
 #hdfs-site.xml
 output_file=$HADOOP_CONF_DIR/hdfs-site.xml
-sed -i -e "s/<\/configuration>//" $output_file
+sudo sed -i -e "s/<\/configuration>//" $output_file
 for k in "${!HDFS_SITE_PROPERTIES[@]}"
 do
 	echo "<property>" >> $output_file
@@ -292,7 +356,7 @@ echo "</configuration>" >> $output_file
 
 #mapred-site.xml
 output_file=$HADOOP_CONF_DIR/mapred-site.xml
-sed -i -e "s/<\/configuration>//" $output_file
+sudo sed -i -e "s/<\/configuration>//" $output_file
 for k in "${!MAPRED_SITE_PROPERTIES[@]}"
 do
 	echo "<property>" >> $output_file
@@ -306,6 +370,11 @@ do
 
 done
 echo "</configuration>" >> $output_file
+syslog_netcat "...Done applying any additional Hadoop parameters."
+
+###################################################################
+# If /etc/hadoop exists, copy hadoop configuration files there too
+###################################################################
 
 if [ -d /etc/hadoop ]
 then
@@ -327,5 +396,5 @@ then
 	fi
 fi
 
-syslog_netcat "....Done...."
+syslog_netcat "Done updating local Hadoop cluster configuration files."
 exit 0

--- a/scripts/hadoop/cb_run_kmeans.sh
+++ b/scripts/hadoop/cb_run_kmeans.sh
@@ -35,7 +35,11 @@ export COMPRESS_GLOBAL=0
 export HADOOP_EXECUTABLE=${HADOOP_HOME}/bin/hadoop
 export MAPRED_EXECUTABLE=${HADOOP_HOME}/bin/mapred
 export HADOOP_EXAMPLES_JAR=${HADOOP_HOME}/hadoop-examples.jar
-export HADOOP_VERSION=hadoop2
+if [[ x${hadoop_version} == *cdh4* ]] ; then
+	export HADOOP_VERSION="cdh4"
+else
+	export HADOOP_VERSION="hadoop2"
+fi
 export HIBENCH_VERSION="2.2"
 export HIBENCH_CONF=${HIBENCH_HOME}/conf
 export HIBENCH_REPORT=${HIBENCH_HOME}/hibench.report
@@ -114,8 +118,8 @@ gen_report "KMEANS" ${START_TIME} ${END_TIME} ${SIZE}
 
 syslog_netcat "Parsing Hadoop config files and HiBench report file for test results..."
 slavecount=`wc -l "${HADOOP_CONF_DIR}/slaves" | awk '{print $1'}`
-lat=`cat ${HIBENCH_REPORT} | grep -v Type | tr -s ' ' | cut -d ' ' -f 5`
-tput=`cat ${HIBENCH_REPORT} | grep -v Type | tr -s ' ' | cut -d ' ' -f 6`
+lat=`cat ${HIBENCH_REPORT} | grep -v Type | tail -1 | tr -s ' ' | cut -d ' ' -f 5`
+tput=`cat ${HIBENCH_REPORT} | grep -v Type | tail -1 | tr -s ' ' | cut -d ' ' -f 6`
 
 syslog_netcat "Reporting results to CloudBench..."
 syslog_netcat "KMEANS results: slaves=${slavecount},samples=${NUM_OF_SAMPLES},clusters=${NUM_OF_CLUSTERS},dimensions=${DIMENSIONS},db_size=${SIZE},db_load_time=${KMEANS_LOAD_TIME},throughput=$tput,run_time=$lat"

--- a/scripts/hadoop/cb_start_hadoop_cluster.sh
+++ b/scripts/hadoop/cb_start_hadoop_cluster.sh
@@ -19,50 +19,171 @@
 source $(echo $0 | sed -e "s/\(.*\/\)*.*/\1.\//g")/cb_hadoop_common.sh
 START=`provision_application_start`
 
-syslog_netcat "Starting Hadoop cluster on master ${hadoop_master_ip} with slaves ${slave_ips_csv} (my ip is ${my_ip_addr})"
+syslog_netcat "Starting Hadoop cluster..."
+if [ x"$my_role" == x"hadoopmaster" ]; then
+	syslog_netcat "Machine ${my_ip_addr} has role of hadoop master"
+else
+	syslog_netcat "Machine ${my_ip_addr} has role of hadoop slave"
+fi
 
-#start mapreduce
+#####################################################################################
+# Start hadoop services / daemons
+#####################################################################################
+
+syslog_netcat "Starting Hadoop services..."
+
 if [ x"$my_role" == x"hadoopmaster" ]; then
 	if [ ${hadoop_use_yarn} -eq 1 ] ; then
 		syslog_netcat "...Formatting Namenode..."
 		${HADOOP_HOME}/bin/hadoop namenode -format -force
+	        if [ $? -ne 0 ] ; then
+                	syslog_netcat "Error when formatting namenode - NOK"
+			exit 1
+		fi
 
 		syslog_netcat "...Starting Namenode daemon..."
 		${HADOOP_HOME}/sbin/hadoop-daemon.sh start namenode
 
 		syslog_netcat "...Starting YARN Resource Manager daemon..."
 		${HADOOP_HOME}/sbin/yarn-daemon.sh start resourcemanager
+
 		syslog_netcat "...Starting Job History daemon..."
 		${HADOOP_HOME}/sbin/mr-jobhistory-daemon.sh start historyserver
 
 	else
-		syslog_netcat "....Formating namenode...."
-		${HADOOP_HOME}/bin/hadoop namenode -format
+		syslog_netcat "...Formating Namenode..."
 
-		syslog_netcat "....starting hadoop services...."
-		syslog_netcat "....starting primary NameNode...."
-		${HADOOP_HOME}/bin/start-dfs.sh
-		syslog_netcat "....starting JobTracker...."
-		${HADOOP_HOME}/bin/start-mapred.sh
-	#	${HADOOP_HOME}/bin/start-all.sh
+		#${HADOOP_HOME}/bin/hadoop namenode -format -force
+		# Default Hadoop permissions require hadoop superuser to format namenode
+		#  Attempt to identify superuser, with default value of hdfs
+
+		DFS_NAME_DIR=`get_my_ai_attribute_with_default dfs_name_dir /tmp/cbhadoopname`
+		set -- `sudo ls -l ${DFS_NAME_DIR}`
+		dfs_name_dir_owner=$5
+
+		if [ x$dfs_name_dir_owner == x ] ; then
+			dfs_name_dir_owner="hdfs"
+		fi
+
+	    	sudo -u ${dfs_name_dir_owner} hadoop namenode -format -force
+	        if [ $? -ne 0 ] ; then
+                	syslog_netcat "Error when formatting namenode as user ${dfs_name_dir_owner} - NOK"
+			exit 1
+		fi
+
+		syslog_netcat "...Namenode formatted."
+
+		syslog_netcat "...Starting primary Namenode service..."
+		if [ -e ${HADOOP_HOME}/bin/start-dfs.sh ]; then
+			syslog_netcat "...start-dfs.sh script exists, using that to launch Namenode services..."
+			${HADOOP_HOME}/bin/start-dfs.sh
+			namenode_running=`ps aux | grep -e [n]amenode`
+			if [ x"$namenode_running" == x ] ; then
+       	                	syslog_netcat "Error - Namenode service did not start - NOK"
+				exit 1
+			else
+       	                	syslog_netcat "...Namenode process appears to be running."
+                        fi
+
+		else
+			syslog_netcat "...No start-dfs script exists. Attempting to identify namenode service..."
+
+			for x in `cd /etc/init.d ; ls *namenode*` ; do 
+				syslog_netcat "...Starting service ${x} ..."
+				sudo /sbin/service $x start 
+				namenode_running=`ps aux | grep -e [n]amenode`
+				if [ x"$namenode_running" == x ] ; then
+                                        # I probably shouldn't hard-code the path to log directory.
+					errorstring=`grep "FATAL\|Exception" /var/log/hadoop-hdfs/*.log`
+        	                	syslog_netcat "Error starting ${x} on ${my_ip_addr}. ${errorstring} NOK"
+					exit 1
+				else
+        	                	syslog_netcat "...Namenode process appears to be running."
+	                        fi
+	                done
+		fi
+
+		syslog_netcat "...Starting JobTracker service..."
+		if [ -e ${HADOOP_HOME}/bin/start-mapred.sh ]; then
+			syslog_netcat "...start-mapred.sh script exists, using that to launch Jobtracker services..."
+			${HADOOP_HOME}/bin/start-mapred.sh
+			jobtracker_running=`ps aux | grep -e [j]obtracker`
+			if [ x"$jobtracker_running" == x ] ; then
+       	                	syslog_netcat "Error starting jobtracker on ${my_ip_addr} - NOK"
+				exit 1
+			else
+       	                	syslog_netcat "...Jobtracker process appears to be running."
+                        fi
+
+		else
+			syslog_netcat "...No start-mapred script exists. Attempting to identify Jobtracker service..."
+
+			for x in `cd /etc/init.d ; ls *jobtracker*` ; do 
+				syslog_netcat "...Starting service ${x} ..."
+				sudo /sbin/service $x start 
+				jobtracker_running=`ps aux | grep -e [j]obtracker`
+				if [ x"$jobtracker_running" == x ] ; then
+        	                	syslog_netcat "Error starting ${x} on ${my_ip_addr} - NOK"
+					exit 1
+				else
+        	                	syslog_netcat "...Jobtracker process appears to be running."
+	                        fi
+	                done
+		fi
+
 	fi
 else
 	if [ ${hadoop_use_yarn} -eq 1 ] ; then
-		syslog_netcat "....starting datanode on ${my_ip_addr} ..."
+		syslog_netcat "...Starting datanode..."
 		${HADOOP_HOME}/sbin/hadoop-daemon.sh start datanode
 		datanode_error=`grep FATAL ${HADOOP_HOME}/logs/hadoop*.log`
 		if [ x"$datanode_error" != x ] ; then
-		        syslog_netcat "Error starting datanode on ${my_ip_addr}: ${datanode_error} "
+		        syslog_netcat "Error starting datanode on ${my_ip_addr}: ${datanode_error} - NOK"
 		        exit 1
 		fi
 		syslog_netcat "....starting nodemanager on ${my_ip_addr} ..."
 		${HADOOP_HOME}/sbin/yarn-daemon.sh start nodemanager
+        else
+		for x in `cd /etc/init.d ; ls *datanode*` ; do 
+			syslog_netcat "...Starting service ${x} ..."
+			sudo /sbin/service $x start 
+			datanode_running=`ps aux | grep -e [d]atanode`
+			if [ x"$datanode_running" == x ] ; then
+ 				errorstring=`grep "FATAL\|Exception" /var/log/hadoop-hdfs/*.log`
+                        	syslog_netcat "Error starting ${x} on ${my_ip_addr}. ${errorstring} - NOK"
+				exit 1
+			else
+       	                	syslog_netcat "...Datanode process appears to be running."
+                        fi
+                done
+
+		for x in `cd /etc/init.d ; ls *tasktracker*` ; do 
+			syslog_netcat "....starting service ${x} on ${my_ip_addr} ..."
+			sudo /sbin/service $x start 
+			tasktracker_running=`ps aux | grep -e [t]asktracker`
+			if [ x"$tasktracker_running" == x ] ; then
+                        	syslog_netcat "Error starting ${x} on ${my_ip_addr} - NOK"
+				exit 1
+			else
+       	                	syslog_netcat "...Tasktracker process appears to be running."
+
+                        fi
+                done
+
 	fi
 fi
 
+#####################################################################################
+# On Master node, wait for all slave datanodes to start
+#####################################################################################
+
+
 if [ x"$my_role" == x"hadoopmaster" ]; then
-	syslog_netcat "Waiting for all Datanodes to become available....."
-	syslog_netcat "`${HADOOP_HOME}/bin/hadoop dfsadmin -report`"
+	syslog_netcat "Waiting for all Datanodes to become available..."
+
+	ATTEMPTS=30
+	# Will wait 5 minutes for datanodes to start; else throw error
+
 	while [ z${DATANODES_AVAILABLE} != z"true" ]
 	do
 	    DFSADMINOUTPUT=`${HADOOP_HOME}/bin/hadoop dfsadmin -report | grep "Datanodes available"`
@@ -74,9 +195,18 @@ if [ x"$my_role" == x"hadoopmaster" ]; then
 	    else
 	        DATANODES_AVAILABLE="false"
 	    fi
-	    sleep 1
+
+	    ((ATTEMPTS=ATTEMPTS-1))
+	    if [ "$ATTEMPTS" -eq 0 ] ; then
+              	syslog_netcat "Timeout Error waiting for datanodes to start. - NOK"
+		syslog_netcat "`${HADOOP_HOME}/bin/hadoop dfsadmin -report`"
+		exit 1
+            fi
+
+	    sleep 10
 	done
-	syslog_netcat "All Datanodes (${TOTAL_NODES}) available now"
+
+	syslog_netcat "...All Datanodes (${TOTAL_NODES}) available."
 
 	if [ ${hadoop_use_yarn} -eq 1 ] ; then
 
@@ -90,6 +220,9 @@ if [ x"$my_role" == x"hadoopmaster" ]; then
 
 fi
 
+#####################################################################################
+# Do...something with a tar file.  I'm Not sure what. 
+#####################################################################################
 
 if [ x"$my_role" == x"hadoopmaster" ]; then
 	if [ -f ~/mm.tar ]; then 
@@ -99,6 +232,6 @@ if [ x"$my_role" == x"hadoopmaster" ]; then
 	fi
 fi
 
-syslog_netcat "......exit......"
+syslog_netcat "Hadoop services started."
 provision_application_stop $START
 exit 0


### PR DESCRIPTION
- Checks for multiple ways to launch hadoop services, based on hadoop version and existence of start scripts in hadoop directories.
- Adds miscellaneous permissions and file-existance checks when launching hadoop.
- Verifies that status returned from launching each hadoop service was successful, and verifies service starts.
- Fixes bug cb_run_kmeans reports statistics to CloudBench
- Adds more descriptive status reports to vCloud Director vm creation code
- Removes <description> section from hadoop configuration files
