### PR TITLE
ibmcb/cbtool issue 58 changes -

### DIFF
--- a/scripts/cassandra_ycsb/cb_ycsb.sh
+++ b/scripts/cassandra_ycsb/cb_ycsb.sh
@@ -75,6 +75,7 @@ sudo sh -c "echo "operationcount=$OPERATION_COUNT" >> $YCSB_PATH/custom_workload
 
 source ~/cb_barrier.sh start
 
+OUTPUT_FILE=$(mktemp)
 if [[ ${GENERATE_DATA} == "true" ]]
 then
 	FIRST_SEED=$(echo $seed_ips_csv | cut -d ',' -f 1)
@@ -85,7 +86,6 @@ then
 	cassandra-cli -h ${FIRST_SEED} -f create_keyspace.cassandra
 				
     syslog_netcat "Number of records to be inserted : $RECORDS"
-    OUTPUT_FILE=$(mktemp)
 
     log_output_command=$(get_my_ai_attribute log_output_command)
     log_output_command=$(echo ${log_output_command} | tr '[:upper:]' '[:lower:]')
@@ -129,9 +129,9 @@ then
     syslog_netcat "Command line is: ${CMDLINE}. Output file is ${OUTPUT_FILE}"
     if [[ $APP_COLLECTION == "lazy" ]]
     then
-        lazy_collection "$CMDLINE" ${SLA_RUNTIME_TARGETS}
+        lazy_collection "$CMDLINE" ${OUTPUT_FILE} ${SLA_RUNTIME_TARGETS}
     else
-        eager_collection "$CMDLINE" ${SLA_RUNTIME_TARGETS}
+        eager_collection "$CMDLINE" ${OUTPUT_FILE} ${SLA_RUNTIME_TARGETS}
     fi
 else
     syslog_netcat "This AI reached the limit of load generation process executions. If you want this AI to continue to execute the load generator, reset the \"run_limit\" counter"

--- a/scripts/cassandra_ycsb/cb_ycsb_common.sh
+++ b/scripts/cassandra_ycsb/cb_ycsb_common.sh
@@ -151,13 +151,15 @@ fi
 function lazy_collection {
 
     CMDLINE=$1
-    SLA_RUNTIME_TARGETS=$2
+    OUTPUT_FILE=$2.run
+    SLA_RUNTIME_TARGETS=$3
         
     ops=0
     latency=0
     
     while read line
     do
+        echo $line >> $OUTPUT_FILE
         IFS=',' read -a array <<< "$line"
         if [[ ${array[0]} == *OVERALL* ]]
         then
@@ -221,7 +223,7 @@ function lazy_collection {
     load_profile:${LOAD_PROFILE}:name \
     load_duration:${LOAD_DURATION}:sec \
     throughput:$(expr $ops):tps \
-    latency:$(expr $latency):ms \
+    latency:$(expr $latency):us \
     datagen_time:${datagentime}:sec \
     datagen_size:${datagensize}:records \
     ${SLA_RUNTIME_TARGETS}
@@ -229,7 +231,8 @@ function lazy_collection {
 
 function eager_collection {
     CMDLINE=$1
-    SLA_RUNTIME_TARGETS=$2
+    OUTPUT_FILE=$2.run
+    SLA_RUNTIME_TARGETS=$3
     
     #----------------------- Track all YCSB results  -------------------------------
 
@@ -253,6 +256,7 @@ function eager_collection {
     
     while read line
     do
+        echo $line >> $OUTPUT_FILE
     #-------------------------------------------------------------------------------
     # Need to track each YCSB Clients current operation count.
     # NEED TO:


### PR DESCRIPTION
 change cassandra latency units to us from ms. 
add ycsb ouptut support for test-phase similar to load-phase. (dump ycsb output to /tmp/)