### PR TITLE
Fixes for random number generation.

### DIFF
--- a/lib/auxiliary/value_generation.py
+++ b/lib/auxiliary/value_generation.py
@@ -140,18 +140,18 @@ class ValueGeneration :
             _fmsg += str(_max) + " (max)"
 
             _distributions = {}
-            _distributions["exponential"] = expovariate(1/_mean)
-            _distributions["uniform"] = uniform(_min, _max)
-            _distributions["gamma"] = gammavariate((_mean * _mean) / (_stdev * _stdev), (_stdev * _stdev) / _mean)
-            _distributions["normal"] = gauss(_mean, _stdev)
+            _distributions["exponential"] = "expovariate(1/_mean)"
+            _distributions["uniform"] = "uniform(_min, _max)"
+            _distributions["gamma"] = "gammavariate((_mean * _mean) / (_stdev * _stdev), (_stdev * _stdev) / _mean)"
+            _distributions["normal"] = "gauss(_mean, _stdev)"
 
             if _distribution in _distributions :        
                 _tries = 0
                 _value = _min - 1.0
 
-                while _value < _min or _value > _max or _tries < _max_tries :
+                while (_value < _min or _value > _max) and _tries < _max_tries :
 
-                    _value = _distributions[_distribution]
+                    _value = eval(_distributions[_distribution])
 
                     _tries += 1
 


### PR DESCRIPTION
Fix loop condition to only loop until value within range generated.
Generate new random value from distribution within loop. (use eval as recommended by Marcio )

quick test program shows values generated within range and with fewer than _max_retries iterations of loop in rand_dist_gen().

Test program:
```
from sys import path, argv
from time import sleep

import fnmatch
import os
import pwd

home = os.environ["HOME"]
username = pwd.getpwuid(os.getuid())[0]

_path_set = False

for _path, _dirs, _files in os.walk(os.path.abspath(path[0] + "/../")):
    for _filename in fnmatch.filter(_files, "code_instrumentation.py") :
        if _path.count("/lib/auxiliary") :
            path.append(_path.replace("/lib/auxiliary",''))
            _path_set = True
            break
    if _path_set :
        break

from lib.api.api_service_client import *
import lib.auxiliary.value_generation as vg

myvg = vg.ValueGeneration(99999)
for i in range(5):
    print myvg.get_value("uniformIXIXI100I150")
for i in range(5):
    print myvg.get_value("normalI100I10I95I105")
for i in range(5):
    print myvg.get_value("exponentialI100I10I95I105")
for i in range(5):
    print myvg.get_value("gammaI100I10I95I105")
```

And, output from program: ( with an extra log statement not in included in commit)
```
$ python test-rand.py
value=130.422617141,tries=1
130.422617141
value=138.771031171,tries=1
138.771031171
value=108.223922207,tries=1
108.223922207
value=127.981913029,tries=1
127.981913029
value=103.04420024,tries=1
103.04420024
value=103.292385797,tries=1
103.292385797
value=99.4451968036,tries=3
99.4451968036
value=100.587140271,tries=1
100.587140271
value=99.0572539545,tries=3
99.0572539545
value=99.8588560487,tries=5
99.8588560487
value=99.4815279281,tries=2
99.4815279281
value=97.8912525299,tries=23
97.8912525299
value=98.5681931228,tries=17
98.5681931228
value=101.974051238,tries=43
101.974051238
value=100.705059505,tries=91
100.705059505
value=99.5023832716,tries=1
99.5023832716
value=96.6677487504,tries=4
96.6677487504
value=96.5147444451,tries=1
96.5147444451
value=101.199449016,tries=1
101.199449016
value=104.833856332,tries=2
104.833856332
```