### PR TITLE
Fix problem with handling of _dash_ with OSK parse_authentication_data

### DIFF
--- a/lib/clouds/osk_cloud_ops.py
+++ b/lib/clouds/osk_cloud_ops.py
@@ -87,7 +87,6 @@ class OskCmds(CommonCloudFunctions) :
 
         elif len(authentication_data.split('-')) == 4 :
             _username, _password, _tenant, _cacert = authentication_data.split('-')
-            _cacert = _cacert.replace("_dash_",'-')
 
         else :
             _username = ''
@@ -110,6 +109,9 @@ class OskCmds(CommonCloudFunctions) :
         try :
             _status = 100
             _fmsg = "An error has occurred, but no error message was captured"
+            # Specify _insecure=True for cases where novaclient insists on using SSLv3
+            # instead of TLS1.2 where only TLS1.2 is allowed.
+            _insecure = False
 
             if len(access_url.split('-')) == 1 :
                 _endpoint_type = "publicURL"
@@ -125,6 +127,7 @@ class OskCmds(CommonCloudFunctions) :
             _username = _username.replace("_dash_",'-')
             _password = _password.replace("_dash_",'-')
             _tenant = _tenant.replace("_dash_",'-')
+            _cacert = _cacert.replace("_dash_",'-')
 
             if _cacert == "NA" :
                 _cacert = None
@@ -135,7 +138,8 @@ class OskCmds(CommonCloudFunctions) :
                                          access_url, region_name = region, \
                                          service_type="compute", \
                                          endpoint_type = _endpoint_type, \
-                                         cacert = _cacert)
+                                         cacert = _cacert, \
+                                         insecure = _insecure )
 
             self.oskconncompute.flavors.list()
 
@@ -150,7 +154,8 @@ class OskCmds(CommonCloudFunctions) :
                                              access_url, region_name=region, \
                                              service_type="volume", \
                                              endpoint_type = _endpoint_type, \
-                                             cacert = _cacert)
+                                             cacert = _cacert, \
+                                             insecure = _insecure )
     
                 self.oskconnstorage.volumes.list()                
             
@@ -170,7 +175,8 @@ class OskCmds(CommonCloudFunctions) :
                                                       region_name = region, \
                                                       service_type="network", \
                                                       endpoint_type = _endpoint_type, \
-                                                      cacert = _cacert)
+                                                      cacert = _cacert, \
+                                                      insecure = _insecure )
     
     
                 self.oskconnnetwork.list_networks()


### PR DESCRIPTION
1) Fix problem with handling of \_dash\_ with OSK parse_authentication_data.  Replacing _dash_ in the CA filename prior to return results in more than 4 items returned. ( and an error from the caller 'too many values to unpack' )

2) Allow for insecure SSL connections with openstack in cases where novaclient insists on using SSLv3.  This in lieu of a real fix to prevent nova client from failing to connect to openstack which does not allow SSLv3.