### PR TITLE
Retrieve user's deploytime distribution for sim clouds if set.

### DIFF
--- a/lib/clouds/sim_cloud_ops.py
+++ b/lib/clouds/sim_cloud_ops.py
@@ -904,10 +904,14 @@ class SimCmds(CommonCloudFunctions) :
             
             for _vm in obj_attr_list["vms"].split(',') :
                 _vm_uuid, _vm_role, _vm_name = _vm.split('|')
+                # default distribution is 10-500.  If the user set distribution, use it.
+                _distribution = 'uniformIXIXI10I500'
+                if 'deployment_time_value' in obj_attr_list:
+                    _distribution = obj_attr_list['deployment_time_value']
 
                 self.osci.pending_object_set(obj_attr_list["cloud_name"], "VM", \
                                              _vm_uuid, "mgt_007_application_start", \
-                                             int(_vg.get_value("uniformIXIXI10I500", 0))) 
+                                             int(_vg.get_value(_distribution, 0)))
 
                 self.osci.pending_object_set(obj_attr_list["cloud_name"], "VM", \
                                              obj_attr_list["uuid"], "status", "Application starting up...") 

--- a/lib/operations/active_operations.py
+++ b/lib/operations/active_operations.py
@@ -4613,7 +4613,11 @@ class ActiveObjectOperations(BaseObjectOperations) :
             _sla_runtime_targets = ''
             for _key in _ai_attr_list :
                 if _key.count("sla_runtime_target") :
-                    _sla_runtime_targets += _key + ':' + _ai_attr_list[_key]
+                    _sla_runtime_targets += _key + ':' + _ai_attr_list[_key] + ','
+            # Strip trailing comma if one or more sla targets were found.
+            # load manager cb_report_app_metrics.py expects SLA targets to be comma separated.
+            if _sla_runtime_targets != '':
+                _sla_runtime_targets = _sla_runtime_targets[:-1]
 
             if _ai_state and _ai_state == "attached" :
                 _load = self.get_load(cloud_name, _ai_attr_list, False, \


### PR DESCRIPTION
SPECCloud uses 'deployment_time' value for sim cloud testing.  With this patch cloudbench honors the user's distribution instead of using default distribution ( uniform|x|x|10|500).