### PR TITLE
Remove unused code used to determine hadoop version.  

### DIFF
--- a/scripts/common/cb_hadoop_common.sh
+++ b/scripts/common/cb_hadoop_common.sh
@@ -70,18 +70,6 @@ fi
 export HADOOP_HOME=${HADOOP_HOME}
 
 syslog_netcat "HADOOP_HOME was determined to be $HADOOP_HOME"     
-HADOOP_VERSION=$(echo ${HADOOP_HOME} | awk -F/ '{print $(NF)}' | sed 's/hadoop-//g' | sed 's/-bin//g')
-    
-re='^[0-9]+$'
-if ! [[ $yournumber =~ $re ]]
-then
-    syslog_netcat "Unable to determine HADOOP_VERSION. Assuming \"2.6\"."
-    HADOOP_VERSION="2.6"
-else
-    syslog_netcat "HADOOP_VERSION was determined to be $HADOOP_VERSION" 
-fi
-
-export HADOOP_VERSION=${HADOOP_VERSION}
 
 if [[ -f ~/.bashrc ]]
 then


### PR DESCRIPTION
Remove HADOOP_VERSION value generation from common hadoop script because the value is not used.  The hadoop version is obtained correctly in other places correctly by using 'hadoop -v'.   
Also, the regular expression used to find hadoop version was incomplete. To match strings such as '2.x.y' it should also have allowed dots in the pattern. The result of this incorrect regular expression was a misleading message in the log suggesting cbtool could not determine the hadoop version.

Removing this code has not negative behavior and reduces confusion from logs.