### PR TITLE
A few last-minute bugs for DigitalOcean

### DIFF
--- a/configs/cloud_definitions.txt
+++ b/configs/cloud_definitions.txt
@@ -103,11 +103,8 @@ DO_KEY_NAME = 1520229                                   # Comma-separated list o
 # Your DO ssh key IDs can be found like this: curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" -X GET "https://api.digitalocean.com/v2/account/keys"
 
 [VM_TEMPLATES : CLOUDOPTION_MYDIGITALOCEAN ]
-TINYVM = size:512mb, imageids:1, imageid1:13991071
+TINYVM = size:512mb, imageids:1, imageid1:foo
 # size options are: 512mb, 1gb, 2gb, etc....
-# Your DO image id can be found like this: curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" -X GET "https://api.digitalocean.com/v2/images?page=1", page2, page3, etc....
-# You'll need to sift through the json to find the corresponding ID
-# We can make lib/clouds/do_cloud_ops.py convert names to IDs later
 #-------------------------------------------------------------------------------
 
 [OBJECTSTORE]

--- a/configs/templates/_digitalocean.txt
+++ b/configs/templates/_digitalocean.txt
@@ -1,4 +1,6 @@
 [USER-DEFINED]
+# We have a lot of servers, but sometimes VM requests take time.
+MAIN_UPDATE_ATTEMPTS = 180
 DO_ACCESS = https://api.digitalocean.com/v2/
 DO_CREDENTIALS = need_to_be_configured_by_user 
 DO_LOGIN = root
@@ -8,7 +10,8 @@ DO_KEY_NAME = need_to_be_configured_by_user
 
 # PEBCAK documentation for the Wizard and CLI
 DO_INITIAL_VMCS_DOC = $INITIAL_VMCS_DOC 
-DO_INITIAL_VMCS_DEFAULT = tor1 
+DO_INITIAL_VMCS_DEFAULT = tor1:sut
+DO_INITIAL_VMCS = nyc3:sut  # VMC == DO data center (we don't have availability zones yet)
 
 [SPACE : DO_CLOUDCONFIG ]
 SSH_KEY_NAME = $DO_SSH_KEY_NAME
@@ -24,6 +27,15 @@ CHECK_BOOT_STARTED = poll_cloud30
 CHECK_BOOT_COMPLETE = tcp_on_22
 SECURITY_GROUPS = not_yet_applicable 
 HOSTNAME_KEY = cloud_vm_name
+ATTACH_PARALLELISM = 1
+
+# We're not as big as amazon yet. Go easy on us please.
+[AI_DEFAULTS]
+ATTACH_PARALLELISM = 1
+
+# We're not as big as amazon yet. Go easy on us please.
+[AIDRS_DEFAULTS]
+ATTACH_PARALLELISM = 1
 
 [MON_DEFAULTS : DO_CLOUDCONFIG ]
 COLLECT_FROM_GUEST = $True
@@ -36,6 +48,9 @@ SSH_KEY_NAME = $DO_SSH_KEY_NAME
 ACCESS = $DO_ACCESS
 SECURITY_GROUPS = not_yet_applicable 
 
+[AI_TEMPLATES : HADOOP ]
+HADOOP_HOME = /usr/local/hadoop 
+
 # DigitalOcean (DO) doesn't have any public images yet.
 # Until then, this section MUST be overriden in your personal
 # configuration file as an example, replacing
@@ -43,8 +58,8 @@ SECURITY_GROUPS = not_yet_applicable
 [VM_TEMPLATES : DO_CLOUDCONFIG ]
 # imageid can be either the actual ID number or more easily the name in the case of a private account
 TINYVM = size:512mb, imageids:1, imageid1:needs_override
-CASSANDRA = size:2gb, imageids:1, imageid1:needs_override
-YCSB = size:2gb, imageids:1, imageid1:needs_override
-SEED = size:2gb, imageids:1, imageid1:needs_override
-HADOOPMASTER = size:1gb, imageids:1, imageid1:needs_override
-HADOOPSLAVE = size:2gb, imageids:1, imageid1:needs_override
+CASSANDRA = size:4gb, imageids:1, imageid1:needs_override
+YCSB = size:4gb, imageids:1, imageid1:needs_override
+SEED = size:4gb, imageids:1, imageid1:needs_override
+HADOOPMASTER = size:2gb, imageids:1, imageid1:needs_override
+HADOOPSLAVE = size:4gb, imageids:1, imageid1:needs_override

--- a/configs/templates/internal_options.txt
+++ b/configs/templates/internal_options.txt
@@ -201,7 +201,7 @@ DONT_START_LOAD_MANAGER = $False
 DONT_START_QEMU_SCRAPER = $True
 RUN_LIMIT = 100000
 REPLICATED_VMS = 0
-ATTACH_PARALLELISM = 1
+ATTACH_PARALLELISM = 20
 DETACH_PARALLELISM = 20
 EXECUTE_PARALLELISM = 6
 RUNSTATE_PARALLELISM = 5
@@ -248,7 +248,7 @@ DETACH_PARALLELISM = 20
 # for objects that don't make sense. Additional filters can be
 # added by clicking on the dashboard and saving the configuration URL
 # in the user's own configuration file
-DASHBOARD_PARAMETERS = dashboard?kb2mb=no&failedvm=yes&4k2mb=no&b2mb=no&p=yes
+DASHBOARD_PARAMETERS = monitor?kb2mb=no&failedvm=yes&4k2mb=no&b2mb=no&p=yes
 DASHBOARD_PARAMETERS += &h=yes&s=yes&a=yes&filter=s-vmc_name,s-vms,h-type,
 DASHBOARD_PARAMETERS +=h-vmc_name,a-vmc_name,h-aidrs_name,h-size,h-age,h-host_name,h-ai_name,h-role,p-vms,a-vms,p-latest_update
 

--- a/lib/clouds/do_cloud_ops.py
+++ b/lib/clouds/do_cloud_ops.py
@@ -215,9 +215,8 @@ class DoCmds(CommonCloudFunctions) :
                 cbdebug(_msg)
                 _status, _fmsg = self.vmccleanup(obj_attr_list)
 
-            obj_attr_list["cloud_hostname"] = "257.0.0.0"
-
-            obj_attr_list["cloud_ip"] = "257.0.0.0"
+            obj_attr_list["cloud_hostname"] = obj_attr_list["name"] 
+            obj_attr_list["cloud_ip"] = obj_attr_list["name"] + ".digitalocean.com"
 
             obj_attr_list["arrival"] = int(time())
 


### PR DESCRIPTION
 A few last-minute bugs for DigitalOcean
    
    1. When running the SPEC harness, we can only allow one VM per AI
       to be created at the same time. More than that, the DigitalOcean
       scheduler appears to add too much delay.
    
       NOTE: DigitalOcean has a 10 or 20 VM limit by default anyway, so
       without further contact with the company through a support ticket
       users will not be able to complete the elasticity run anyway.
       The baseline run will be fine, but the elasticity run will not work.
    
    2. One VMC related bug and setting the default VMC to New York.