### PR TITLE
UTC timestamps, VPN problems, and DigitalOcean defaults.

### DIFF
--- a/configs/templates/_digitalocean.txt
+++ b/configs/templates/_digitalocean.txt
@@ -28,6 +28,7 @@ CHECK_BOOT_COMPLETE = tcp_on_22
 SECURITY_GROUPS = not_yet_applicable 
 HOSTNAME_KEY = cloud_vm_name
 ATTACH_PARALLELISM = 1
+SIZE = from_vm_template
 
 # We're not as big as amazon yet. Go easy on us please.
 [AI_DEFAULTS]
@@ -61,5 +62,5 @@ TINYVM = size:512mb, imageids:1, imageid1:needs_override
 CASSANDRA = size:4gb, imageids:1, imageid1:needs_override
 YCSB = size:4gb, imageids:1, imageid1:needs_override
 SEED = size:4gb, imageids:1, imageid1:needs_override
-HADOOPMASTER = size:2gb, imageids:1, imageid1:needs_override
+HADOOPMASTER = size:4gb, imageids:1, imageid1:needs_override
 HADOOPSLAVE = size:4gb, imageids:1, imageid1:needs_override

--- a/lib/api/api_service_client.py
+++ b/lib/api/api_service_client.py
@@ -79,7 +79,7 @@ def makeTimestamp(supplied_epoch_time = False) :
     TBD
     '''
     if not supplied_epoch_time :
-        _now = datetime.now()
+        _now = datetime.utcnow()
     else :
         _now = datetime.fromtimestamp(supplied_epoch_time)
         
@@ -91,7 +91,7 @@ def makeTimestamp(supplied_epoch_time = False) :
                         strptime(str(_now.hour) + ":" + str(_now.minute) + ":" + \
                                  str(_now.second), "%H:%M:%S"))
         
-    result += strftime(" %Z", localtime(time())) 
+    result += " UTC"
     return result
 
 class APIVM():

--- a/lib/auxiliary/data_ops.py
+++ b/lib/auxiliary/data_ops.py
@@ -201,7 +201,7 @@ def makeTimestamp(supplied_epoch_time = False) :
     TBD
     '''
     if not supplied_epoch_time :
-        _now = datetime.now()
+        _now = datetime.utcnow()
     else :
         _now = datetime.fromtimestamp(supplied_epoch_time)
         
@@ -213,7 +213,7 @@ def makeTimestamp(supplied_epoch_time = False) :
                         strptime(str(_now.hour) + ":" + str(_now.minute) + ":" + \
                                  str(_now.second), "%H:%M:%S"))
         
-    result += strftime(" %Z", localtime(time())) 
+    result += " UTC"
     return result
 
 @trace

--- a/lib/auxiliary/data_ops.py
+++ b/lib/auxiliary/data_ops.py
@@ -410,7 +410,7 @@ def create_user_data_contents(obj_attr_list, osci) :
                 
     _userdata_contents += get_boostrap_command(obj_attr_list, osci).replace(';','\n')
 
-    if obj_attr_list["use_vpn_ip"].lower() != "false" :
+    if obj_attr_list["use_vpn_ip"].lower() != "false" and obj_attr_list["vpn_only"].lower() == "false" :
         _userdata_contents += "\nmkdir /var/log/openvpn\n"
         _userdata_contents += "chmod 777 /var/log/openvpn\n"
         _file_fd = open(obj_attr_list["vpn_config_file"], 'r')

--- a/lib/clouds/do_cloud_ops.py
+++ b/lib/clouds/do_cloud_ops.py
@@ -316,7 +316,7 @@ class DoCmds(CommonCloudFunctions) :
             _msg += " Private IP = " + obj_attr_list["cloud_ip"]
             cbdebug(_msg)
 
-            if obj_attr_list["use_vpn_ip"].lower() == "true" :
+            if str(obj_attr_list["use_vpn_ip"]).lower() == "true" and str(obj_attr_list["vpn_only"]).lower() == "true" :
                 assert(self.get_attr_from_pending(obj_attr_list))
 
                 if "cloud_init_vpn" not in obj_attr_list :

--- a/lib/clouds/shared_functions.py
+++ b/lib/clouds/shared_functions.py
@@ -225,7 +225,10 @@ class CommonCloudFunctions:
                 cbdebug(_msg, True)
                 _actual_wait = 0
 
-            if str(obj_attr_list["use_vpn_ip"]).lower() != "false" :
+            # There is still some reconciliation to be done here. If vpn_only is used, then only openvpn-initiated callbacks should set the pending attribute, not userdata scripts. There is a distinction. It also means that public_cloud_ip should be set as well and that access to pending attributes is a requirement. See get_ip_address from do_cloud_ops.py
+            # Also "use_vpn_ip" is used throughout the scripts and codebase, so use_vpn_ip is already reserved to ensure that vpn_only works as it did before.
+            # So any changes to use_vpn_ip need to be conditionalized with an extra check to vpn_only as well.
+            if str(obj_attr_list["use_vpn_ip"]).lower() != "false" and obj_attr_list["vpn_only"].lower() == "false" :
                 if self.get_attr_from_pending(obj_attr_list, "cloud_init_vpn") :
                     obj_attr_list["last_known_state"] = "ACTIVE with (vpn) ip assigned"
                     obj_attr_list["prov_cloud_ip"] = obj_attr_list["cloud_init_vpn"]  

--- a/scenarios/common.py
+++ b/scenarios/common.py
@@ -546,7 +546,7 @@ def makeTimestamp(supplied_epoch_time = False) :
     TBD
     '''
     if not supplied_epoch_time :
-        _now = datetime.now()
+        _now = datetime.utcnow()
     else :
         _now = datetime.fromtimestamp(supplied_epoch_time)
 
@@ -558,7 +558,7 @@ def makeTimestamp(supplied_epoch_time = False) :
                         strptime(str(_now.hour) + ":" + str(_now.minute) + ":" + \
                                  str(_now.second), "%H:%M:%S"))
 
-    result += strftime(" %Z", localtime(time()))
+    result += " UTC" 
     return result
 
 def check_samples(options, api, start_time, max_time) :

--- a/scripts/common/cb_common.py
+++ b/scripts/common/cb_common.py
@@ -26,7 +26,7 @@
 from logging import getLogger, StreamHandler, Formatter, Filter, DEBUG, ERROR, \
 INFO, WARN, CRITICAL
 from logging.handlers import logging, SysLogHandler, RotatingFileHandler
-from time import time, sleep, strftime
+from time import time, sleep
 from datetime import datetime
 from sys import path, argv, stdout
 from subprocess import Popen, PIPE, STDOUT
@@ -49,6 +49,7 @@ import urllib
 
 from lib.auxiliary.code_instrumentation import VerbosityFilter, MsgFilter
 from lib.auxiliary.code_instrumentation import cbdebug, cberr, cbwarn, cbinfo, cbcrit
+from lib.auxiliary.data_ops import makeTimestamp
 
 class NetworkException(Exception) :
     '''
@@ -757,10 +758,11 @@ def report_app_metrics(metriclist, sla_targets_list, ms_conn = "auto", \
         if "app_sla_runtime" in _metrics_dict :
             _metrics_dict["app_sla_runtime"]["val"] = _sla_status
     
-        _metrics_dict["time"] = int(time())
+        tzoffset = datetime.utcfromtimestamp(-1).hour - datetime.fromtimestamp(0).hour + 1
+        _metrics_dict["time"] = int(time()) + (3600 * tzoffset)
         _metrics_dict["time_cbtool"] = _osci.get_remote_time()[0]
-        _metrics_dict["time_h"] = strftime("%a %b %d %X %Z %Y")
-        _metrics_dict["time_cbtool_h"] = datetime.fromtimestamp(int(_metrics_dict["time_cbtool"])).strftime("%a %b %d %X %Z %Y")        
+        _metrics_dict["time_h"] = makeTimestamp() 
+        _metrics_dict["time_cbtool_h"] = makeTimestamp(_metrics_dict["time_cbtool"])
         _metrics_dict["expid"] = _expid
         _metrics_dict["uuid"] = _my_uuid
         

--- a/scripts/common/cb_timebound_exec.py
+++ b/scripts/common/cb_timebound_exec.py
@@ -11,11 +11,11 @@ for _command in _commands :
     _complete = False
     while _current_attempts <= _attempts and not _complete :
         _complete = True
-        start = datetime.datetime.now()
+        start = datetime.datetime.utcnow()
         process = subprocess.Popen(_command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         while process.poll() is None :
             time.sleep(0.1)
-            now = datetime.datetime.now()
+            now = datetime.datetime.utcnow()
             if (now - start).seconds > _timeout:
                 os.kill(process.pid, signal.SIGKILL)
                 os.waitpid(-1, os.WNOHANG)

--- a/util/openvpn/client.conf.template
+++ b/util/openvpn/client.conf.template
@@ -5,6 +5,11 @@ remote DESTINATION VPN_PORT
 
 log /var/log/openvpn/USERNAME_openvpn-cb.log
 
+# This script was designed for the VPN client, not the server.
+# If you, for whatever reason, need the VPN server to run
+# a script as well, please create a new one when VPN_ONLY = False
+up /etc/openvpn/client_connected.sh
+
 ca       [inline]
 cert     [inline]
 key      [inline]

--- a/util/openvpn/client_connected.sh
+++ b/util/openvpn/client_connected.sh
@@ -8,9 +8,25 @@ if [ $0 != "-bash" ] ; then
 	popd 2>&1 > /dev/null
 fi
 
-logpath=/var/log/cloudbench/$USER_openvpn_client.log
+mkdir -p /var/log/cloudbench
+
+logpath=/var/log/cloudbench/${USER}_openvpn_client.log
+tap=$1
+mtu=$2
+other_mtu=$3
+VPNIP=$4
+peer=$5
+dunno=$6
 
 echo "client connected $(date) params: $@" >> $logpath
+
+# This is deliberate: We *must* call redis-cli here when VPN_ONLY = $True 
+# because is this the only time which the VPN is fully connected. It cannot be
+# called earlier.
+(bash -c "sleep 5; redis-cli -h SERVER_BOOTSTRAP -n OSCI_DBID -p OSCI_PORT hset TEST_USER:CLOUD_NAME:VM:PENDING:UUID cloud_init_vpn $VPNIP" &)
+
+# Run cloudbench's cloud-agnostic userdata later. Backwards compatible with VPN_ONLY = False
+(/tmp/userscript.sh &)
 
 env | sort >> $logpath
 

--- a/util/openvpn/server.conf.template
+++ b/util/openvpn/server.conf.template
@@ -5,7 +5,13 @@ port VPN_PORT
 server VPN_ADDRESS_RANGE 
 
 log LOGDIR/USERNAME_openvpn_server.log
-client-connect CBPATH/util/openvpn/client_connected.sh
+
+#This was not what this script was designed for. It called 'client_connected'
+#because the VPN client is supposed to execute it from within the VM,
+#not the server.
+# If you, for whatever reason, need the VPN server to run
+# a script as well, please create a new one when VPN_ONLY = False
+#client-connect CBPATH/util/openvpn/client_connected.sh
 
 ca       [inline]
 cert     [inline]


### PR DESCRIPTION
    First, make the codebase use UTC timestamps instead of local timestamps.
    
    There are other calls to time.time() which may still not be in UTC,
    but this at least fixes all calls to datetime.now() to use datetime.utcnow()
    instead.
    
    There is one example in this patch showing how to repair calls to time.time()
    if needed.

    Second, Repair broken VPN_ONLY support ---- please see comments inline in the code.
    
    VPN_ONLY is supposed to be checked for in the code and client_connected.sh
    should be responsible for calling redis-cli *inside* the VM only after
    then VPN connection is confirmed established and the only way to do that
    is for the VPN client to execute the script.

   Finally, add additional DigitalOcean defaults that were missing.
