### PR TITLE
VPN support for Amazon EC2

### DIFF
--- a/configs/templates/_digitalocean.txt
+++ b/configs/templates/_digitalocean.txt
@@ -27,7 +27,6 @@ CHECK_BOOT_STARTED = poll_cloud30
 CHECK_BOOT_COMPLETE = tcp_on_22
 SECURITY_GROUPS = not_yet_applicable 
 HOSTNAME_KEY = cloud_vm_name
-ATTACH_PARALLELISM = 1
 SIZE = from_vm_template
 
 # We're not as big as amazon yet. Go easy on us please.
@@ -36,7 +35,7 @@ ATTACH_PARALLELISM = 1
 
 # We're not as big as amazon yet. Go easy on us please.
 [AIDRS_DEFAULTS]
-ATTACH_PARALLELISM = 1
+DAEMON_PARALLELISM = 1
 
 [MON_DEFAULTS : DO_CLOUDCONFIG ]
 COLLECT_FROM_GUEST = $True


### PR DESCRIPTION
This commit unifies cloud-init based support for bootstrapping OpenVPN connections. It enhances EC2 to use the mechanism in exactly the same way that DigitalOcean does, sharing code to send the appropriate user-data without duplicated any code.

It has been tested with all of the SPEC Cloud 2016 applications on our own Amazon EC2 account and works well from a laptop outside of Amazon running CloudBench connected through an OpenVPN server running on Amazon which then deploys workloads also on Amazon.