### PR TITLE
One more UTC bugfix for the road

### DIFF
--- a/scripts/common/cb_common.py
+++ b/scripts/common/cb_common.py
@@ -758,9 +758,7 @@ def report_app_metrics(metriclist, sla_targets_list, ms_conn = "auto", \
         if "app_sla_runtime" in _metrics_dict :
             _metrics_dict["app_sla_runtime"]["val"] = _sla_status
     
-#        tzoffset = datetime.utcfromtimestamp(-1).hour - datetime.fromtimestamp(0).hour + 1
-#        _metrics_dict["time"] = int(time()) + (3600 * tzoffset)
-        _metrics_dict["time"] = _metrics_dict["time"] = int(mktime(datetime.utcnow().timetuple()))
+        _metrics_dict["time"] = _metrics_dict["time"] = int(time())
         _metrics_dict["time_cbtool"] = _osci.get_remote_time()[0]
         _metrics_dict["time_h"] = makeTimestamp() 
         _metrics_dict["time_cbtool_h"] = makeTimestamp(_metrics_dict["time_cbtool"])


### PR DESCRIPTION
So, most of the UTC repairs we performed last year were correct, except for this one.

Unix "epochs" by themselves are timezone-less. It's when they are "interpreted" as human-readable
timestamps that they are parsed by python incorrectly.

When these epochs (from time()) are directly compared to each other, they are timezone-less,
and do not need to be offset.

But, when they are "fed" to python to be converted as human-readable, those rare cases are
when the timezones get lost.

We've already handled correctly in the past when human timestamps are compared to human
timestamps --- that all works fine --- no repair needed there.

However, the mongodb gmetad adapter also was doing this wrong --- see the PR associated with it.