### PR TITLE
Load Manager bug fix: Looping too fast on "stopped" AIs

### DIFF
--- a/lib/operations/active_operations.py
+++ b/lib/operations/active_operations.py
@@ -4767,6 +4767,7 @@ class ActiveObjectOperations(BaseObjectOperations) :
                 _msg += "current load will be allowed to finish its course."
                 cbdebug(_msg)
                 self.parallel_vm_config_for_ai(cloud_name, object_uuid, "reset")
+                sleep(_check_frequency)
 
         _msg = "AI \"state key\" was removed. The Load Manager will now end its execution"
         cbdebug(_msg)


### PR DESCRIPTION
Load Manager bug fix: Looping too fast on "stopped" AIs

One-line fix to make the load manager stop taking up 100% CPU
when SPEC sets the AI state to "stopped"