### PR TITLE
Runcount issue bugfix

### DIFF
--- a/lib/operations/base_operations.py
+++ b/lib/operations/base_operations.py
@@ -2301,7 +2301,10 @@ class BaseObjectOperations :
                             
                 _obj_attr_list = self.osci.get_object(cloud_name, "VM", False, _vm_uuid, False)
                 
-                _abort, _fmsg, _remaining_time = self.pending_decide_abortion(_obj_attr_list, "VM")
+                if operation != "reset" :
+                    _abort, _fmsg, _remaining_time = self.pending_decide_abortion(_obj_attr_list, "VM")
+                else :
+                    _remaining_time = 100000
 
                 if _remaining_time < _smallest_remaining_time :
                     _smallest_remaining_time = _remaining_time
@@ -2504,10 +2507,11 @@ class BaseObjectOperations :
                         _fmsg += _xfmsg
                         break
 
-                    for _vm in _vm_list :                        
-                        _vm_uuid, _vm_role, _vm_name = _vm.split('|')                                    
-                        _obj_attr_list = self.osci.get_object(cloud_name, "VM", False, _vm_uuid, False)                        
-                        self.pending_decide_abortion(_obj_attr_list, "VM")
+                    if operation != "reset" :
+                        for _vm in _vm_list :
+                            _vm_uuid, _vm_role, _vm_name = _vm.split('|')
+                            _obj_attr_list = self.osci.get_object(cloud_name, "VM", False, _vm_uuid, False)
+                            self.pending_decide_abortion(_obj_attr_list, "VM")
 
         except Exception, e :
             _status = 23

--- a/lib/operations/base_operations.py
+++ b/lib/operations/base_operations.py
@@ -2507,11 +2507,10 @@ class BaseObjectOperations :
                         _fmsg += _xfmsg
                         break
 
-                    if operation != "reset" :
-                        for _vm in _vm_list :
-                            _vm_uuid, _vm_role, _vm_name = _vm.split('|')
-                            _obj_attr_list = self.osci.get_object(cloud_name, "VM", False, _vm_uuid, False)
-                            self.pending_decide_abortion(_obj_attr_list, "VM")
+                    for _vm in _vm_list :
+                        _vm_uuid, _vm_role, _vm_name = _vm.split('|')
+                        _obj_attr_list = self.osci.get_object(cloud_name, "VM", False, _vm_uuid, False)
+                        self.pending_decide_abortion(_obj_attr_list, "VM")
 
         except Exception, e :
             _status = 23


### PR DESCRIPTION
The provisioning violation checks were happening long after the AI
had already been successfully provisioned within tolerance. This
fix ensures that checks do not happen during the "reset" phase
of the load manager.

Marcio, please double-check this PR. I did two tests:
1. Full spec run ----- normal run counts
2. Then, I artificially did `typealter hadoop hadoopmaster_sla_provisioning_target 10` and verified I got this error message: `Ran out of time to run generic post_boot scripts due to the established SLA provisioning target.`

Everything looks good on my end.