### PR TITLE
DigitalOcean block storage volume support

### DIFF
--- a/lib/auxiliary/gui.py
+++ b/lib/auxiliary/gui.py
@@ -543,7 +543,7 @@ class Dashboard () :
                     if not gfilter.count(dest + "-") :
                         continue
                     output += "[<a href='" + self.prefix() + "/monitor?remove=" + gfilter + "' target='_top'>X</a>] " + \
-                        gfilter.split("-")[1].replace("_", " ") + "&nbsp;"
+                        gfilter.split("-", 1)[1].replace("_", " ") + "&nbsp;"
             
         output += """
                     </div>

--- a/lib/auxiliary/gui.py
+++ b/lib/auxiliary/gui.py
@@ -118,7 +118,7 @@ class Dashboard () :
         elif "cloud_ip" in attrs and attrs["cloud_ip"] == "undefined" :
             return False
         elif metrics is not None and "last_known_state" in metrics :
-            if metrics["last_known_state"].count("with ip assigned") == 0 :
+            if metrics["last_known_state"].count("with ip assigned") == 0 and metrics["last_known_state"].count("generic post-boot script executed") == 0:
                 return True
             else :
                 return False

--- a/lib/clouds/do_cloud_ops.py
+++ b/lib/clouds/do_cloud_ops.py
@@ -183,6 +183,33 @@ class DoCmds(CommonCloudFunctions) :
                 _msg += " were terminated"
                 cbdebug(_msg)
 
+            _running_volumes = True
+            while _running_volumes :
+                _running_volumes = False
+                for credential_pair in obj_attr_list["credentials"].split(","):
+                    credentials = credential_pair.split(":")
+                    tenant = credentials[0]
+
+                    _volumes = catalogs.digitalocean[credential_pair].list_volumes()
+                    for _volume in _volumes :
+                        if _volume.name.count("cb-" + obj_attr_list["username"]) :
+                            try :
+                                cbdebug("Destroying: " + _volume.name + " (" + tenant + ")", True)
+                                _volume.destroy()
+                            except :
+                                pass
+                            _running_volumes = True
+                        else :
+                            _msg = "Cleaning up DigitalOcean. Ignoring volume: " + _volume.name
+                            cbdebug(_msg)
+
+                    if _running_volumes :
+                        sleep(int(obj_attr_list["update_frequency"]))
+
+                _msg = "All volumes on DigitalOcean " + obj_attr_list["name"]
+                _msg += " were destroyed"
+                cbdebug(_msg)
+
             _status = 0
 
         except CldOpsException, obj :
@@ -411,15 +438,13 @@ class DoCmds(CommonCloudFunctions) :
 
     @trace
     def vmcreate(self, obj_attr_list) :
-        '''
-        TBD
-        '''
-        try :
-            _status = 100
-            _fmsg = "An error has occurred when creating new Droplet, but no error message was captured"
+        _status = 100
+        _fmsg = "An error has occurred when creating new Droplet, but no error message was captured"
+        obj_attr_list["cloud_vm_uuid"] = "NA"
+        _instance = False
+        volume = False
 
-            obj_attr_list["cloud_vm_uuid"] = "NA"
-            _instance = False
+        try :
 
             obj_attr_list["cloud_vm_name"] = "cb-" + obj_attr_list["username"]
             obj_attr_list["cloud_vm_name"] += '-' + "vm" + obj_attr_list["name"].split("_")[1]
@@ -529,13 +554,71 @@ class DoCmds(CommonCloudFunctions) :
                     del obj_attr_list["instance_obj"]
 
                 _status = 0
-
             else :
                 obj_attr_list["last_known_state"] = "vm creation failed"
                 _fmsg = "Failed to obtain instance's (cloud-assigned) uuid. The "
                 _fmsg += "instance creation failed for some unknown reason."
                 cberr(_fmsg)
                 _status = 100
+
+
+            if "cloud_vv" in obj_attr_list :
+                _status = 101
+
+                obj_attr_list["last_known_state"] = "about to send volume create request"
+
+                obj_attr_list["cloud_vv_name"] = "cb-" + obj_attr_list["username"]
+                obj_attr_list["cloud_vv_name"] += '-' + "vv"
+                obj_attr_list["cloud_vv_name"] += obj_attr_list["name"].split("_")[1]
+                obj_attr_list["cloud_vv_name"] += '-' + obj_attr_list["role"]
+                if obj_attr_list["ai"] != "none" :
+                    obj_attr_list["cloud_vv_name"] += '-' + obj_attr_list["ai_name"]
+
+                obj_attr_list["cloud_vv_name"] = obj_attr_list["cloud_vv_name"].replace("_", "-")
+
+                _msg = "Creating a volume, with size "
+                _msg += obj_attr_list["cloud_vv"] + " GB, on VMC \""
+                _msg += obj_attr_list["vmc_name"] + "\" with name " + obj_attr_list["cloud_vv_name"] + "..."
+                cbdebug(_msg, True)
+
+                _mark1 = int(time())
+
+                volume = catalogs.digitalocean[credential_pair].create_volume(int(obj_attr_list["cloud_vv"]),
+                                                                              obj_attr_list["cloud_vv_name"],
+                                                                              location = [x for x in self.locations if x.id == obj_attr_list["vmc_name"]][0])
+
+                sleep(int(obj_attr_list["update_frequency"]))
+
+                obj_attr_list["cloud_vv_uuid"] = volume.id
+
+                _mark2 = int(time())
+                obj_attr_list["do_015_create_volume_time"] = _mark2 - _mark1
+
+                if volume :
+                    _mark3 = int(time())
+                    _msg = "Attaching the newly created Volume \""
+                    _msg += obj_attr_list["cloud_vv_name"] + "\" (cloud-assigned uuid \""
+                    _msg += obj_attr_list["cloud_vv_uuid"] + "\") to instance \""
+                    _msg += obj_attr_list["cloud_vm_name"] + "\" (cloud-assigned uuid \""
+                    _msg += obj_attr_list["cloud_vm_uuid"] + "\")"
+                    cbdebug(_msg)
+
+                    if not volume.attach(_reservation) :
+                        msg = "Volume attach failed. Aborting VM creation..."
+                        cbdebug(msg, True)
+                        volume.destroy()
+                        raise CldOpsException(msg, _status)
+
+                    cbdebug("Volume attach success.", True)
+                    _mark4 = int(time())
+                    obj_attr_list["do_015_create_volume_time"] += (_mark4 - _mark3)
+                    _status = 0
+                else :
+                    msg = "Volume creation failed. Aborting VM creation..."
+                    cbdebug(msg, True)
+                    raise CldOpsException(msg, _status)
+            else :
+                obj_attr_list["cloud_vv_uuid"] = "none"
 
         except CldOpsException, obj :
             _status = obj.status
@@ -563,6 +646,7 @@ class DoCmds(CommonCloudFunctions) :
                 else :
                     if _reservation :
                         _reservation.destroy()
+
                 raise CldOpsException(_msg, _status)
             else :
                 _msg = "VM " + obj_attr_list["uuid"] + " was successfully "
@@ -630,6 +714,21 @@ class DoCmds(CommonCloudFunctions) :
             obj_attr_list["last_known_state"] = "vm destoyed"
             _time_mark_drc = int(time())
             obj_attr_list["mgt_903_deprovisioning_request_completed"] = _time_mark_drc - _time_mark_drs
+
+            if "cloud_vv_name" in obj_attr_list :
+                tenant = credential_pair.split(":")[0]
+                cbdebug("Checking for volumes from tenant: " + tenant)
+                _volumes = catalogs.digitalocean[credential_pair].list_volumes()
+                for _volume in _volumes :
+                    if _volume.name == obj_attr_list["cloud_vv_name"] :
+                        try :
+                            cbdebug("Destroying: " + _volume.name + " (" + tenant + ")", True)
+                            _volume.destroy()
+                            break
+                        except :
+                            pass
+                    else :
+                        cbdebug("Ignoring volume: " + _volume.name)
 
             _status = 0
 
@@ -912,3 +1011,4 @@ class DoCmds(CommonCloudFunctions) :
                 _msg += "\"."
                 cbdebug(_msg)
                 return _status, _msg
+

--- a/scripts/common/cb_common.sh
+++ b/scripts/common/cb_common.sh
@@ -454,7 +454,7 @@ function mount_filesystem_on_volume {
             if [[ $(check_filesystem $VOLUME) == "none" ]]
             then
                 syslog_netcat "Creating $FILESYS_TYPE filesystem on volume $VOLUME"
-                sudo mkfs.$FILESYS_TYPE $VOLUME
+                sudo mkfs.$FILESYS_TYPE -F $VOLUME
             fi
             
             syslog_netcat "Making $FILESYS_TYPE filesystem on volume $VOLUME accessible through the mountpoint ${MOUNTPOINT_DIR}"
@@ -511,7 +511,7 @@ function mount_filesystem_on_memory {
         if [[ $(check_filesystem $RAMDEVICE) == "none" ]]
         then
             syslog_netcat "Creating $FILESYS_TYPE filesystem on volume $VOLUME"
-            sudo mkfs.$FILESYS_TYPE $RAMDEVICE
+            sudo mkfs.$FILESYS_TYPE -F $RAMDEVICE
         fi        
 
         syslog_netcat "Making $FILESYS_TYPE filesystem on ram disk $RAMDEVICE accessible through the mountpoint ${MOUNTPOINT_DIR}"

--- a/scripts/ibm_daytrader_ppc64le/cb_setup_ramdisk.sh
+++ b/scripts/ibm_daytrader_ppc64le/cb_setup_ramdisk.sh
@@ -35,7 +35,7 @@ if [[ x"${RAMDISK}" == x || x"${RAMDISK}" == "false" ]]; then
 else
 	syslog_netcat "Setting RAMDISK (${RAMDISK_DEVICE} for holding DB2 database ${DATABASE_NAME} on host ($SHORT_HOSTNAME)"
 	sudo mkdir ${DATABASE_PATH} 
-	sudo mkfs.ext4 /dev/ram0
+	sudo mkfs.ext4 -F /dev/ram0
 	sudo mount /dev/ram0 $DATABASE_PATH
 	sudo chown ${my_login_username}:${my_login_username} $DATABASE_PATH
 	syslog_netcat "Copying ${DATABASE_PATH}_${SIZE} contents to ${DATABASE_PATH}"

--- a/scripts/mongo_ycsb/cb_restart_mongo.sh
+++ b/scripts/mongo_ycsb/cb_restart_mongo.sh
@@ -42,7 +42,7 @@ then
     if [[ $(check_filesystem $VOLUME) == "none" ]]
     then
         syslog_netcat "Creating $MONGODB_DATA_FSTYP filesystem on volume $VOLUME"
-        sudo mkfs.$MONGODB_DATA_FSTYP $VOLUME
+        sudo mkfs.$MONGODB_DATA_FSTYP -F $VOLUME
     fi
     syslog_netcat "Making $MONGODB_DATA_FSTYP filesystem on volume $VOLUME accessible through the mountpoint ${MONGODB_DATA_DIR}"
     sudo mount $VOLUME ${MONGODB_DATA_DIR}

--- a/scripts/mongo_ycsb/cb_restart_mongo_cfg.sh
+++ b/scripts/mongo_ycsb/cb_restart_mongo_cfg.sh
@@ -23,7 +23,7 @@ then
     if [[ $(check_filesystem $VOLUME) == "none" ]]
     then
         syslog_netcat "Creating $MONGODB_DATA_FSTYP filesystem on volume $VOLUME"
-        sudo mkfs.$MONGODB_DATA_FSTYP $VOLUME
+        sudo mkfs.$MONGODB_DATA_FSTYP -F $VOLUME
     fi
     syslog_netcat "Making $MONGODB_DATA_FSTYP filesystem on volume $VOLUME accessible through the mountpoint ${MONGODB_DATA_DIR}"
     sudo mount $VOLUME ${MONGODB_DATA_DIR}

--- a/scripts/open_daytrader/cb_setup_ramdisk.sh
+++ b/scripts/open_daytrader/cb_setup_ramdisk.sh
@@ -35,7 +35,7 @@ if [[ x"${RAMDISK}" == x || x"${RAMDISK}" == "false" ]]; then
 else
 	syslog_netcat "Setting RAMDISK (${RAMDISK_DEVICE} for holding DB2 database ${DATABASE_NAME} on host ($SHORT_HOSTNAME)"
 	sudo mkdir ${DATABASE_PATH} 
-	sudo mkfs.ext4 /dev/ram0
+	sudo mkfs.ext4 -F /dev/ram0
 	sudo mount /dev/ram0 $DATABASE_PATH
 	sudo chown klabuser:klabuser $DATABASE_PATH
 	syslog_netcat "Copying ${DATABASE_PATH}_${SIZE} contents to ${DATABASE_PATH}"


### PR DESCRIPTION
1. We formally released block storage support *today* out of beta. NOTE: libcloud must be upgraded for it to work.
2. The 'mkfs` command used by all the CB scripts was not making use of the '-F' force flag. Without it, the flag cause mkfs to wait on standard input to type 'Y' in some cases.
3. The GUI was not handling some cases of 'last_known_state' and not showing filters correctly.