### PR TITLE
Fix for submitter always at 100% CPU

### DIFF
--- a/lib/clouds/do_cloud_ops.py
+++ b/lib/clouds/do_cloud_ops.py
@@ -327,8 +327,8 @@ class DoCmds(CommonCloudFunctions) :
             elif obj_attr_list["hostname_key"] == "cloud_ip" :
                 obj_attr_list["cloud_hostname"] = obj_attr_list["cloud_ip"].replace('.','-')
 
-            _msg = "Public IP = " + node.public_ips[0]
-            _msg += " Private IP = " + obj_attr_list["cloud_ip"]
+            _msg = "Public IP = " + str(node.public_ips)
+            _msg += " Private IP = " + str(node.private_ips)
             cbdebug(_msg)
 
             if str(obj_attr_list["use_vpn_ip"]).lower() == "true" and str(obj_attr_list["vpn_only"]).lower() == "true" :

--- a/lib/operations/active_operations.py
+++ b/lib/operations/active_operations.py
@@ -4898,7 +4898,7 @@ class ActiveObjectOperations(BaseObjectOperations) :
 
                 _inter_arrival_time = int(time()) - _inter_arrival_time_start
                 
-                if _inter_arrival_time - _curr_iait < _check_frequency :
+                if abs(_inter_arrival_time - _curr_iait) < _check_frequency :
                     sleep(_check_frequency/10)
                 else :
                     sleep(_check_frequency)


### PR DESCRIPTION
The calculation in the submitter is always negative, and thus always causes the submitter to sleep for (5 / 10) = 0.5 seconds, which always appears to be spinning at 100%. Two submitters doing this thus takes up 2 whole cores. 

Using the absolute value instead fixes the problem ---- but I'm not entirely sure if that's what you were going for @maugustosilva.

The second commit is for DigitalOcean --- a printing error.