### PR TITLE
fix wrong DigitalOcean provisioning time

### DIFF
--- a/lib/auxiliary/gui.py
+++ b/lib/auxiliary/gui.py
@@ -66,6 +66,7 @@ class Dashboard () :
         self.time_vars = time_vars 
         self.base_uri = base_uri
         self.start_time = int(self.time_vars["start_time"])
+        self.pid = "none"
         self.processid = "none"
         self.cn = cloud_name
         self.msattrs = msattrs

--- a/lib/clouds/do_cloud_ops.py
+++ b/lib/clouds/do_cloud_ops.py
@@ -491,6 +491,8 @@ class DoCmds(CommonCloudFunctions) :
 
             cbdebug("Launching new Droplet with hostname " + obj_attr_list["cloud_vm_name"], True)
 
+            obj_attr_list["mgt_001_provisioning_request_originated"] = int(time())
+
             _reservation = catalogs.digitalocean[credential_pair].create_node(
                 image = image,
                 name = obj_attr_list["cloud_vm_name"],
@@ -576,13 +578,7 @@ class DoCmds(CommonCloudFunctions) :
             _status = 100
             _fmsg = "An error has occurred, but no error message was captured"
 
-            _time_mark_drs = int(time())
             _wait = int(obj_attr_list["update_frequency"])
-
-            if "mgt_901_deprovisioning_request_originated" not in obj_attr_list :
-                obj_attr_list["mgt_901_deprovisioning_request_originated"] = _time_mark_drs
-
-            obj_attr_list["mgt_902_deprovisioning_request_sent"] = _time_mark_drs - int(obj_attr_list["mgt_901_deprovisioning_request_originated"])
 
             cbdebug("Last known state: " + str(obj_attr_list["last_known_state"]))
 
@@ -597,6 +593,7 @@ class DoCmds(CommonCloudFunctions) :
             _msg += "...."
             cbdebug(_msg, True)
 
+            firsttime = True
             while True :
                 _errmsg = "get_vm_instance"
                 cbdebug("Getting instance...")
@@ -615,7 +612,17 @@ class DoCmds(CommonCloudFunctions) :
                     continue
 
                 try :
+                    _time_mark_drs = int(time())
+                    if firsttime :
+                        if "mgt_901_deprovisioning_request_originated" not in obj_attr_list :
+                            obj_attr_list["mgt_901_deprovisioning_request_originated"] = _time_mark_drs
+
                     result = _instance.destroy()
+
+                    if firsttime :
+                        obj_attr_list["mgt_902_deprovisioning_request_sent"] = _time_mark_drs - int(obj_attr_list["mgt_901_deprovisioning_request_originated"])
+
+                    firsttime = False
                 except :
                     pass
 

--- a/lib/clouds/do_cloud_ops.py
+++ b/lib/clouds/do_cloud_ops.py
@@ -559,7 +559,7 @@ class DoCmds(CommonCloudFunctions) :
                 cberr(_msg)
 
                 if "cloud_vm_uuid" in obj_attr_list :
-                    obj_attr_list["mgt_deprovisioning_request_originated"] = int(time())
+                    obj_attr_list["mgt_901_deprovisioning_request_originated"] = int(time())
                     self.vmdestroy(obj_attr_list)
                 else :
                     if _reservation :

--- a/lib/clouds/do_cloud_ops.py
+++ b/lib/clouds/do_cloud_ops.py
@@ -491,8 +491,6 @@ class DoCmds(CommonCloudFunctions) :
 
             cbdebug("Launching new Droplet with hostname " + obj_attr_list["cloud_vm_name"], True)
 
-            obj_attr_list["mgt_001_provisioning_request_originated"] = int(time())
-
             _reservation = catalogs.digitalocean[credential_pair].create_node(
                 image = image,
                 name = obj_attr_list["cloud_vm_name"],
@@ -866,6 +864,9 @@ class DoCmds(CommonCloudFunctions) :
                 obj_attr_list["credentials_pair"] = credentials_pair
                 self.osci.pending_object_set(obj_attr_list["cloud_name"], "AI", \
                     obj_attr_list["uuid"], "credential_pair", credentials_pair)
+
+                # Cache libcloud objects for this daemon / process before the VMs are attached
+                self.connect(credentials_pair)
 
             _fmsg = "An error has occurred, but no error message was captured"
 


### PR DESCRIPTION
We were calculating "request_originated" incorrectly. Fix that.

The same thing probably goes for alibaba and VMware, as those things were carried over from the older vmware implementation, but those are not fixed here.