### PR TITLE
SPECCloud: Fix wrong DigitalOcean provisioning time

### DIFF
--- a/lib/auxiliary/gui.py
+++ b/lib/auxiliary/gui.py
@@ -66,6 +66,7 @@ class Dashboard () :
         self.time_vars = time_vars 
         self.base_uri = base_uri
         self.start_time = int(self.time_vars["start_time"])
+        self.pid = "none"
         self.processid = "none"
         self.cn = cloud_name
         self.msattrs = msattrs

--- a/lib/clouds/do_cloud_ops.py
+++ b/lib/clouds/do_cloud_ops.py
@@ -683,7 +683,9 @@ class DoCmds(CommonCloudFunctions) :
                 _instance = self.get_vm_instance(obj_attr_list)
                 if not _instance :
                     cbdebug("Breaking...")
-                    _time_mark_drs = int(time())
+                    if firsttime :
+                        if "mgt_901_deprovisioning_request_originated" not in obj_attr_list :
+                            obj_attr_list["mgt_901_deprovisioning_request_originated"] = _time_mark_drs
                     break
 
                 if _instance.state == NodeState.PENDING :

--- a/lib/clouds/do_cloud_ops.py
+++ b/lib/clouds/do_cloud_ops.py
@@ -354,7 +354,7 @@ class DoCmds(CommonCloudFunctions) :
             elif obj_attr_list["hostname_key"] == "cloud_ip" :
                 obj_attr_list["cloud_hostname"] = obj_attr_list["cloud_ip"].replace('.','-')
 
-            _msg = "Public IP = " + node.public_ips[0]
+            _msg = "Public IP = " + str(node.public_ips[0])
             _msg += " Private IP = " + obj_attr_list["cloud_ip"]
             cbdebug(_msg)
 
@@ -677,6 +677,7 @@ class DoCmds(CommonCloudFunctions) :
             cbdebug(_msg, True)
 
             firsttime = True
+            _time_mark_drs = int(time())
             while True :
                 _errmsg = "get_vm_instance"
                 cbdebug("Getting instance...")
@@ -698,7 +699,6 @@ class DoCmds(CommonCloudFunctions) :
                     continue
 
                 try :
-                    _time_mark_drs = int(time())
                     if firsttime :
                         if "mgt_901_deprovisioning_request_originated" not in obj_attr_list :
                             obj_attr_list["mgt_901_deprovisioning_request_originated"] = _time_mark_drs
@@ -706,7 +706,7 @@ class DoCmds(CommonCloudFunctions) :
                     result = _instance.destroy()
 
                     if firsttime :
-                        obj_attr_list["mgt_902_deprovisioning_request_sent"] = _time_mark_drs - int(obj_attr_list["mgt_901_deprovisioning_request_originated"])
+                        obj_attr_list["mgt_902_deprovisioning_request_sent"] = int(time()) - int(obj_attr_list["mgt_901_deprovisioning_request_originated"])
 
                     firsttime = False
                 except :

--- a/lib/clouds/do_cloud_ops.py
+++ b/lib/clouds/do_cloud_ops.py
@@ -30,6 +30,7 @@ from libcloud.compute.providers import get_driver
 from libcloud.compute.types import NodeState
 
 import threading
+import traceback
 
 catalogs = threading.local()
 
@@ -626,6 +627,8 @@ class DoCmds(CommonCloudFunctions) :
             cbwarn("Error during reservation creation: " + _fmsg)
 
         except Exception, e :
+            for line in traceback.format_exc().splitlines() :
+                cbwarn(line, True)
             _status = 23
             _fmsg = str(e)
             cbwarn("Error reaching digitalocean: " + _fmsg)
@@ -746,6 +749,8 @@ class DoCmds(CommonCloudFunctions) :
             cberr("CldOpsException: " + str(obj), True)
 
         except Exception, e :
+            for line in traceback.format_exc().splitlines() :
+                cbwarn(line, True)
             _status = 23
             _fmsg = str(e)
             cberr("Exception: " + str(e), True)

--- a/lib/clouds/do_cloud_ops.py
+++ b/lib/clouds/do_cloud_ops.py
@@ -641,7 +641,7 @@ class DoCmds(CommonCloudFunctions) :
                 cberr(_msg)
 
                 if "cloud_vm_uuid" in obj_attr_list :
-                    obj_attr_list["mgt_deprovisioning_request_originated"] = int(time())
+                    obj_attr_list["mgt_901_deprovisioning_request_originated"] = int(time())
                     self.vmdestroy(obj_attr_list)
                 else :
                     if _reservation :
@@ -661,13 +661,7 @@ class DoCmds(CommonCloudFunctions) :
             _status = 100
             _fmsg = "An error has occurred, but no error message was captured"
 
-            _time_mark_drs = int(time())
             _wait = int(obj_attr_list["update_frequency"])
-
-            if "mgt_901_deprovisioning_request_originated" not in obj_attr_list :
-                obj_attr_list["mgt_901_deprovisioning_request_originated"] = _time_mark_drs
-
-            obj_attr_list["mgt_902_deprovisioning_request_sent"] = _time_mark_drs - int(obj_attr_list["mgt_901_deprovisioning_request_originated"])
 
             cbdebug("Last known state: " + str(obj_attr_list["last_known_state"]))
 
@@ -682,12 +676,14 @@ class DoCmds(CommonCloudFunctions) :
             _msg += "...."
             cbdebug(_msg, True)
 
+            firsttime = True
             while True :
                 _errmsg = "get_vm_instance"
                 cbdebug("Getting instance...")
                 _instance = self.get_vm_instance(obj_attr_list)
                 if not _instance :
                     cbdebug("Breaking...")
+                    _time_mark_drs = int(time())
                     break
 
                 if _instance.state == NodeState.PENDING :
@@ -700,7 +696,17 @@ class DoCmds(CommonCloudFunctions) :
                     continue
 
                 try :
+                    _time_mark_drs = int(time())
+                    if firsttime :
+                        if "mgt_901_deprovisioning_request_originated" not in obj_attr_list :
+                            obj_attr_list["mgt_901_deprovisioning_request_originated"] = _time_mark_drs
+
                     result = _instance.destroy()
+
+                    if firsttime :
+                        obj_attr_list["mgt_902_deprovisioning_request_sent"] = _time_mark_drs - int(obj_attr_list["mgt_901_deprovisioning_request_originated"])
+
+                    firsttime = False
                 except :
                     pass
 
@@ -958,6 +964,9 @@ class DoCmds(CommonCloudFunctions) :
                 obj_attr_list["credentials_pair"] = credentials_pair
                 self.osci.pending_object_set(obj_attr_list["cloud_name"], "AI", \
                     obj_attr_list["uuid"], "credential_pair", credentials_pair)
+
+                # Cache libcloud objects for this daemon / process before the VMs are attached
+                self.connect(credentials_pair)
 
             _fmsg = "An error has occurred, but no error message was captured"
 

--- a/lib/clouds/do_cloud_ops.py
+++ b/lib/clouds/do_cloud_ops.py
@@ -354,8 +354,8 @@ class DoCmds(CommonCloudFunctions) :
             elif obj_attr_list["hostname_key"] == "cloud_ip" :
                 obj_attr_list["cloud_hostname"] = obj_attr_list["cloud_ip"].replace('.','-')
 
-            _msg = "Public IP = " + str(node.public_ips[0])
-            _msg += " Private IP = " + obj_attr_list["cloud_ip"]
+            _msg = "Public IP = " + str(node.public_ips)
+            _msg += " Private IP = " + str(node.private_ips)
             cbdebug(_msg)
 
             if str(obj_attr_list["use_vpn_ip"]).lower() == "true" and str(obj_attr_list["vpn_only"]).lower() == "true" :


### PR DESCRIPTION
1. This is a driver-only fix which makes sure we do the proper libcloud-initializations during the aidefine() function.
2. We also have some minor GUI cleanup issue in here in the way numbers were detected and displayed that also relate to provisioning time in libcloud-based drivers.