### PR TITLE
Stop using "0.0.0.0" in hadoop everywhere

### DIFF
--- a/scripts/hadoop/cb_config_hadoop_cluster.sh
+++ b/scripts/hadoop/cb_config_hadoop_cluster.sh
@@ -96,6 +96,13 @@ do
 	echo "</property>" >> $output_file
 
 done
+cat << EOF >> $output_file
+<property>
+  <name>fs.ftp.host</name>
+  <value>${my_ip_addr}</value>
+  <description>FTP filesystem connects to this server</description>
+</property>
+EOF
 echo "</configuration>" >> $output_file 
 
 #hdfs-site.xml
@@ -113,7 +120,146 @@ do
 	echo "</property>" >> $output_file
 
 done
+cat << EOF >> $output_file
+<property>
+  <name>dfs.namenode.secondary.http-address</name>
+  <value>${my_ip_addr}:50090</value>
+  <description>
+    The secondary namenode http server address and port.
+  </description>
+</property>
+<property>
+  <name>dfs.namenode.secondary.https-address</name>
+  <value>${my_ip_addr}:50091</value>
+  <description>
+    The secondary namenode HTTPS server address and port.
+  </description>
+</property>
+<property>
+  <name>dfs.datanode.address</name>
+  <value>${my_ip_addr}:50010</value>
+  <description>
+    The datanode server address and port for data transfer.
+  </description>
+</property>
+<property>
+  <name>dfs.datanode.http.address</name>
+  <value>${my_ip_addr}:50075</value>
+  <description>
+    The datanode http server address and port.
+  </description>
+</property>
+<property>
+  <name>dfs.datanode.ipc.address</name>
+  <value>${my_ip_addr}:50020</value>
+  <description>
+    The datanode ipc server address and port.
+  </description>
+</property>
+<property>
+  <name>dfs.namenode.http-address</name>
+  <value>${my_ip_addr}:50070</value>
+  <description>
+    The address and the base port where the dfs namenode web ui will listen on.
+  </description>
+</property>
+<property>
+  <name>dfs.datanode.https.address</name>
+  <value>${my_ip_addr}:50475</value>
+  <description>The datanode secure http server address and port.</description>
+</property>
+
+<property>
+  <name>dfs.namenode.https-address</name>
+  <value>${my_ip_addr}:50470</value>
+  <description>The namenode secure http server address and port.</description>
+</property>
+ <property>
+  <name>dfs.namenode.backup.address</name>
+  <value>${my_ip_addr}:50100</value>
+  <description>
+    The backup node server address and port.
+    If the port is 0 then the server will start on a free port.
+  </description>
+</property>
+ <property>
+  <name>dfs.namenode.backup.http-address</name>
+  <value>${my_ip_addr}:50105</value>
+  <description>
+    The backup node http server address and port.
+    If the port is 0 then the server will start on a free port.
+  </description>
+</property>
+<property>
+  <name>dfs.journalnode.rpc-address</name>
+  <value>${my_ip_addr}:8485</value>
+  <description>
+    The JournalNode RPC server address and port.
+  </description>
+</property>
+
+<property>
+  <name>dfs.journalnode.http-address</name>
+  <value>${my_ip_addr}:8480</value>
+  <description>
+    The address and port the JournalNode HTTP server listens on.
+    If the port is 0 then the server will start on a free port.
+  </description>
+</property>
+
+<property>
+  <name>dfs.journalnode.https-address</name>
+  <value>${my_ip_addr}:8481</value>
+  <description>
+    The address and port the JournalNode HTTPS server listens on.
+    If the port is 0 then the server will start on a free port.
+  </description>
+</property>
+EOF
 echo "</configuration>" >> $output_file 
+
+#yarn-site.xml
+output_file=$HADOOP_CONF_DIR/yarn-site.xml
+sudo sed -i -e "s/<\/configuration>//" $output_file
+
+cat << EOF >> $output_file
+<property>
+    <description>Address where the localizer IPC is.</description>
+    <name>yarn.nodemanager.localizer.address</name>
+    <value>${my_ip_addr}:8040</value>
+  </property>
+<property>
+    <description>NM Webapp address.</description>
+    <name>yarn.nodemanager.webapp.address</name>
+    <value>${my_ip_addr}:8042</value>
+ </property>
+<property>
+    <description>The hostname of the RM.</description>
+    <name>yarn.resourcemanager.hostname</name>
+    <value>${my_ip_addr}</value>
+  </property>
+ <property>
+    <description>The hostname of the NM.</description>
+    <name>yarn.nodemanager.hostname</name>
+    <value>${my_ip_addr}</value>
+  </property>
+<property>
+    <description>The hostname of the timeline service web application.</description>
+    <name>yarn.timeline-service.hostname</name>
+    <value>${my_ip_addr}</value>
+  </property>
+  <property>
+    <description>The address of the RM admin interface.</description>
+    <name>yarn.resourcemanager.admin.address</name>
+    <value>${my_ip_addr}:8033</value>
+  </property>
+  <property>
+    <description>The http address of the RM web application.</description>
+    <name>yarn.resourcemanager.webapp.address</name>
+    <value>${my_ip_addr}:8088</value>
+  </property>
+</configuration>
+EOF
 
 #mapred-site.xml
 output_file=$HADOOP_CONF_DIR/mapred-site.xml
@@ -131,6 +277,18 @@ do
 	echo "</property>" >> $output_file
 
 done
+cat << EOF >> $output_file
+<property>
+  <name>mapreduce.jobhistory.admin.address</name>
+  <value>${my_ip_addr}:10033</value>
+  <description>The address of the History server admin interface.</description>
+</property>
+<property>
+  <name>mapreduce.jobhistory.webapp.address</name>
+  <value>${my_ip_addr}:19888</value>
+  <description>MapReduce JobHistory Server Web UI host:port</description>
+</property>
+EOF
 echo "</configuration>" >> $output_file
 syslog_netcat "...Done applying any additional Hadoop parameters."
 


### PR DESCRIPTION
While this doesn't entirely solve our port binding issues that we're struggling to solve, at the very least this cleans up the way we bind to ports.

This commit makes all the hadoop explicitly bound to the interfaces that matters instead
of the default 0.0.0.0.

I've combed through all the known-used ports and tried to include all the relevant ones
that are are required in CloudBench.