### PR TITLE
SPEC v1.1: another missing API parameter

### DIFF
--- a/lib/api/api_service_client.py
+++ b/lib/api/api_service_client.py
@@ -366,7 +366,7 @@ class APIClient(Server):
         '''
         TBD
         '''
-        _metrics = self.get_performance_data(cloud_name, uuid, "management", "VM", True, 0, expid)
+        _metrics = self.get_performance_data(cloud_name, uuid, "management", "VM", "os", True, 0, expid)
 
         return _metrics
 


### PR DESCRIPTION
This parameter was missing too. To be totally honest, I'm not sure
why the harness was working in the first place without this parameter.

(I don't know how many months back the extra parameter appeared, but
this one was missing too).