### PR TITLE
one-line fix to restore libcloud multi-tenancy

### DIFF
--- a/lib/clouds/libcloud_common.py
+++ b/lib/clouds/libcloud_common.py
@@ -208,7 +208,7 @@ class LibcloudCmds(CommonCloudFunctions) :
         # libcloud is totally not thread-safe. bastards.
         cbdebug("Checking libcloud connection...")
         try :
-            getattr(LibcloudCmds.catalogs, self.description)
+            getattr(LibcloudCmds.catalogs, "cbtool")
         except AttributeError, e :
             cbdebug("Initializing thread local connection: ")
 


### PR DESCRIPTION
I tried my best to get the super-class perfect, but I just missed a single line of code. =) Silly me.

But this is a good example of fixing a bug that's common to all libcloud adapters without having to modify everybody's adapter at the same time.