### PR TITLE
monextract performance

### DIFF
--- a/lib/auxiliary/code_instrumentation.py
+++ b/lib/auxiliary/code_instrumentation.py
@@ -24,10 +24,18 @@
     @author: Marcio A. Silva, Michael R. Hines
 '''
 
+from __future__ import print_function
 from logging.handlers import logging
 from logging import getLogger, StreamHandler, Formatter, Filter, DEBUG, ERROR, INFO
-from sys import _getframe
+from sys import getsizeof, stderr, _getframe
+from itertools import chain
+from collections import deque
 import __builtin__
+
+try:
+    from reprlib import repr
+except ImportError:
+    pass
 
 bins = dir(__builtin__)
 
@@ -214,3 +222,48 @@ class MsgFilter(Filter) :
         self.expr = expr
     def filter(self, record) :
         return not record.getMessage().count(self.expr)
+
+# Taken from https://code.activestate.com/recipes/577504/
+
+def total_size(o, handlers={}, verbose=False):
+    """ Returns the approximate memory footprint an object and all of its contents.
+
+    Automatically finds the contents of the following builtin containers and
+    their subclasses:  tuple, list, deque, dict, set and frozenset.
+    To search other containers, add handlers to iterate over their contents:
+
+        handlers = {SomeContainerClass: iter,
+                    OtherContainerClass: OtherContainerClass.get_elements}
+
+    """
+    dict_handler = lambda d: chain.from_iterable(d.items())
+    all_handlers = {tuple: iter,
+                    list: iter,
+                    deque: iter,
+                    dict: dict_handler,
+                    set: iter,
+                    frozenset: iter,
+                   }
+    all_handlers.update(handlers)     # user handlers take precedence
+    seen = set()                      # track which object id's have already been seen
+    default_size = getsizeof(0)       # estimate sizeof object without __sizeof__
+
+    def sizeof(o):
+        if id(o) in seen:       # do not double count the same object
+            return 0
+        seen.add(id(o))
+        s = getsizeof(o, default_size)
+
+        if verbose:
+            print(s, type(o), repr(o), file=stderr)
+
+        for typ, handler in all_handlers.items():
+            if isinstance(o, typ):
+                s += sum(map(sizeof, handler(o)))
+                break
+        return s
+
+    return sizeof(o)
+
+
+    print(total_size(d, verbose=True))


### PR DESCRIPTION
This commit significantly improves "monextract" performance
by reducing memory usage and adding more calls to the database
and by removing the sort when not necessary.

I also included a little utility function here which you can point at ANY python object
to determine the true, in-memory size of the object.

We can use this function for further trimming CloudBench memory usage in the future.