### PR TITLE
Auto-restart load manager

### DIFF
--- a/scripts/btest/cb_run_btest.sh
+++ b/scripts/btest/cb_run_btest.sh
@@ -64,7 +64,7 @@ lat=`grep "Total:" ${RUN_OUTPUT_FILE} | grep -v ms | cut -d " " -f 8`
 
 ~/cb_report_app_metrics.py \
 throughput:${tp}:tps \
-latency:${lat}:msec \
+latency:${lat}:usec \
 $(common_metrics)    
     
 unset_load_gen

--- a/scripts/common/cb_common.sh
+++ b/scripts/common/cb_common.sh
@@ -1633,6 +1633,18 @@ function get_offline_ip {
     ip -o addr show $(ip route | grep default | grep -oE "dev [a-z]+[0-9]+" | sed "s/dev //g") | grep -Eo "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | grep -v 255
 }
 
+function setup_rclocal_restarts {
+    if [ x"$(grep cb_start_load_manager.sh /etc/rc.local)" == x ] ; then
+        echo "cb_start_load_manager.sh is missing from /etc/rc.local"
+        cat /etc/rc.local | grep -v "exit 0" > /tmp/rc.local
+        chmod +x /tmp/rc.local
+		echo "su $(whoami) -c \"$dir/cb_start_load_manager.sh\"" >> /tmp/rc.local
+        echo "exit 0" >> /tmp/rc.local
+        mv -f /tmp/rc.local /etc/rc.local
+        
+    fi
+}
+
 function automount_data_dirs {
     #    ROLE_DATA_DIR=$(get_my_ai_attribute_with_default ${my_role}_data_dir none)
     #    ROLE_DATA_FSTYP=$(get_my_ai_attribute_with_default ${my_role}_data_fstyp local)

--- a/scripts/common/cb_post_boot.sh
+++ b/scripts/common/cb_post_boot.sh
@@ -54,6 +54,7 @@ then
     syslog_netcat "Starting (AI) Object store..."
     start_redis ${osportnumber}
     syslog_netcat "Local (AI) Object store started"
+    setup_rclocal_restarts
 fi
 
 refresh_hosts_file


### PR DESCRIPTION
This enhancement installs a command into /etc/rc.local that allows
an application to restart itself after a hypervisor reboots.

It doesn't work very well with hadoop, but it works perfectly with
Cassandra.

Hadoop seems to be much more complex to automatically restart a VM
that has already joined the cluster. Requires more investigation.