### PR TITLE
Support for VPN connection errors

### DIFF
--- a/lib/clouds/libcloud_common.py
+++ b/lib/clouds/libcloud_common.py
@@ -897,10 +897,9 @@ class LibcloudCmds(CommonCloudFunctions) :
 
             if self.use_ssh_keys :
 
-                keys = []
-    
                 tmp_keys = obj_attr_list["key_name"].split(",")
                 for dontcare in range(0, 2) :
+                    keys = []
                     for tmp_key in tmp_keys :
                         for key in LibcloudCmds.keys[_credentials_list] :
                             if tmp_key in [key.name, key.extra["id"]] and key.extra["id"] not in keys and key.name not in keys :

--- a/lib/clouds/shared_functions.py
+++ b/lib/clouds/shared_functions.py
@@ -1239,11 +1239,11 @@ write_files:"""
                     line = line.replace("UUID", obj_attr_list["uuid"])
                     line = line.replace("OSCI_PORT", str(self.osci.port))
                     line = line.replace("OSCI_DBID", str(self.osci.dbid))
-                    if line.count("remote") :
+                    if line.count("remote ") :
                         line = "remote " + obj_attr_list["vpn_server_ip"] + " " + obj_attr_list["vpn_server_port"] + "\n"
                     cloudconfig += "      " + line
 
-                    if line.count("remote") :
+                    if line.count("remote ") :
                         cloudconfig += "      up /etc/openvpn/client_connected.sh\n"
                 fh.close()
 

--- a/lib/operations/active_operations.py
+++ b/lib/operations/active_operations.py
@@ -2234,7 +2234,8 @@ class ActiveObjectOperations(BaseObjectOperations) :
         _proc_man = ProcessManagement(username = obj_attr_list["login"], \
                                       cloud_name = obj_attr_list["cloud_name"], \
                                       priv_key = obj_attr_list["identity"], \
-                                      config_file = _config_file)
+                                      config_file = _config_file,
+                                      connection_timeout = 120)
 
         try :
             
@@ -2264,14 +2265,17 @@ class ActiveObjectOperations(BaseObjectOperations) :
                 _msg += ": " + _ssh_cmd_log + " \"" + _cmd + "\"..."
                 cbdebug(_msg, selectively_print_message("check_ssh", obj_attr_list))
                 _proc_man.retriable_run_os_command(_cmd, \
-                                                   obj_attr_list["prov_cloud_ip"], \
+                                                   obj_attr_list["uuid"], \
                                                    _actual_tries, \
                                                    _retry_interval, \
                                                    obj_attr_list["check_ssh"], \
                                                    obj_attr_list["debug_remote_commands"], \
                                                    True,
                                                    tell_me_if_stderr_contains = False, \
-                                                   port = obj_attr_list["prov_cloud_port"])
+                                                   port = obj_attr_list["prov_cloud_port"], \
+                                                           osci = self.osci, \
+                                                           get_hostname_using_key = "prov_cloud_ip" \
+                                                   )
 
             self.osci.update_object_attribute(obj_attr_list["cloud_name"], "VM", obj_attr_list["uuid"], \
                                               False, "last_known_state", \
@@ -2305,14 +2309,16 @@ class ActiveObjectOperations(BaseObjectOperations) :
                 cbdebug(_msg)
 
                 _proc_man.retriable_run_os_command(_bcmd, \
-                                                   obj_attr_list["prov_cloud_ip"], \
+                                                   obj_attr_list["uuid"], \
                                                    _actual_tries, \
                                                    _retry_interval, \
                                                    obj_attr_list["transfer_files"], \
                                                    obj_attr_list["debug_remote_commands"], \
                                                    True, \
                                                    tell_me_if_stderr_contains = "Connection reset by peer", \
-                                                   port = obj_attr_list["prov_cloud_port"])
+                                                   port = obj_attr_list["prov_cloud_port"], \
+                                                           osci = self.osci, \
+                                                           get_hostname_using_key = "prov_cloud_ip")
 
             _msg = "Bootstrapped " + obj_attr_list["log_string"]
             cbdebug(_msg)
@@ -2386,14 +2392,18 @@ class ActiveObjectOperations(BaseObjectOperations) :
 
                 _cmd = "~/" + obj_attr_list["remote_dir_name"] + "/scripts/common/cb_post_boot.sh"
                 
-                _status, _xfmsg, _object = \
-                _proc_man.run_os_command(_cmd, obj_attr_list["prov_cloud_ip"], \
-                                         obj_attr_list["run_generic_scripts"], \
-                                         obj_attr_list["debug_remote_commands"], \
-                                         True, \
-                                         tell_me_if_stderr_contains = "Connection reset by peer", \
-                                         port = obj_attr_list["prov_cloud_port"])                    
-
+                _status, _result_stdout, _result_stderr = \
+                        _proc_man.retriable_run_os_command(_cmd, obj_attr_list["uuid"], \
+                                                           really_execute = obj_attr_list["run_generic_scripts"], \
+                                                           debug_cmd = obj_attr_list["debug_remote_commands"], \
+                                                           total_attempts = int(obj_attr_list["update_attempts"]),\
+                                                           retry_interval = int(obj_attr_list["update_frequency"]), \
+                                                           raise_exception_on_error = True, \
+                                                           tell_me_if_stderr_contains = "Connection reset by peer", \
+                                                           port = obj_attr_list["prov_cloud_port"], \
+                                                           osci = self.osci, \
+                                                           get_hostname_using_key = "prov_cloud_ip"  \
+                                                           )
                 _time_mark_ipbc = int(time())
                 _delay = _time_mark_ipbc - obj_attr_list["time_mark_aux"]
                              
@@ -2401,7 +2411,6 @@ class ActiveObjectOperations(BaseObjectOperations) :
                     _fmsg = "Failure while executing generic VM "
                     _fmsg += "post_boot configuration on "
                     _fmsg += obj_attr_list["name"] + '.\n'
-#                            _fmsg += _xfmsg
                 else :
 
                     self.osci.update_object_attribute(obj_attr_list["cloud_name"], "VM", obj_attr_list["uuid"], \

--- a/lib/operations/base_operations.py
+++ b/lib/operations/base_operations.py
@@ -49,7 +49,7 @@ class BaseObjectOperations :
     TBD
     '''
     default_cloud = None
-    proc_man_os_command = ProcessManagement()
+    proc_man_os_command = ProcessManagement(connection_timeout = 120)
 
     @trace
     def __init__ (self, osci, msci, attached_clouds = []) :
@@ -2388,7 +2388,7 @@ class BaseObjectOperations :
             _vm_hns = []
             _vm_pns = []
             _vm_roles = []
-            _vm_ip_addrs = []
+            _vm_uuids = []
             _vm_logins = []
             _vm_passwds = []
             _vm_priv_keys = []
@@ -2423,11 +2423,12 @@ class BaseObjectOperations :
                 _vm_hns.append(_obj_attr_list["cloud_hostname"])
                 
                 _vm_roles.append(_obj_attr_list["role"])
+                _vm_uuids.append(_vm_uuid)
                 if operation != "reset" :
-                    _vm_ip_addrs.append(_obj_attr_list["prov_cloud_ip"])
-                    _vm_pns.append(_obj_attr_list["prov_cloud_port"])                    
+                    _which_key = "prov_cloud_ip"
+                    _vm_pns.append(_obj_attr_list["prov_cloud_port"])
                 else :
-                    _vm_ip_addrs.append(_obj_attr_list["run_cloud_ip"])
+                    _which_key = "run_cloud_ip"
                     _vm_pns.append(_obj_attr_list["run_cloud_port"])
                                         
                 _vm_logins.append(_obj_attr_list["login"])
@@ -2494,15 +2495,17 @@ class BaseObjectOperations :
                 if _actual_attempts > 0 :
                     _post_boot_start = int(time())
                     _status, _xfmsg = self.proc_man_os_command.parallel_run_os_command(_vm_post_boot_commands, \
-                                                                        _vm_ip_addrs, \
+                                                                        _vm_uuids, \
                                                                         _vm_pns, \
                                                                         _actual_attempts, \
                                                                         int(_ai_attr_list["update_frequency"]), \
                                                                         _ai_attr_list["execute_parallelism"], \
-                                                                        _obj_attr_list["run_generic_scripts"], \
-                                                                        _obj_attr_list["debug_remote_commands"], \
-                                                                        "0", \
-                                                                        _smallest_remaining_time)
+                                                                        really_execute = _obj_attr_list["run_generic_scripts"], \
+                                                                        debug_cmd = _obj_attr_list["debug_remote_commands"], \
+                                                                        step = "0", \
+                                                                        remaining_time = _smallest_remaining_time, \
+                                                                        osci = self.osci, \
+                                                                        get_hostname_using_key = _which_key)
                     sleep(float(_ai_attr_list["post_generic_scripts_delay"]))                    
                     _post_boot_spent_time = int(time()) - _post_boot_start
                 else :
@@ -2660,7 +2663,7 @@ class BaseObjectOperations :
                     if _actual_attempts > 0 :
                         _application_start = int(time())                        
                         _status, _xfmsg = self.proc_man_os_command.parallel_run_os_command(_vm_command_list, \
-                                                                            _vm_ip_addrs, \
+                                                                            _vm_uuids, \
                                                                             _vm_pns, \
                                                                             _actual_attempts, \
                                                                             int(_ai_attr_list["update_frequency"]), \
@@ -2668,7 +2671,9 @@ class BaseObjectOperations :
                                                                             _ai_attr_list["run_application_scripts"], 
                                                                             _ai_attr_list["debug_remote_commands"],
                                                                             _num, \
-                                                                            _smallest_remaining_time)
+                                                                            _smallest_remaining_time, \
+                                                                            osci = self.osci, \
+                                                                            get_hostname_using_key = _which_key)
                         
                         sleep(float(_ai_attr_list["post_application_scripts_delay"]))
                         _application_spent_time = int(time()) - _application_start                        

--- a/util/openvpn/client_connected.sh
+++ b/util/openvpn/client_connected.sh
@@ -23,7 +23,12 @@ echo "client connected $(date) params: $@" >> $logpath
 # This is deliberate: We *must* call redis-cli here when VPN_ONLY = $True 
 # because is this the only time which the VPN is fully connected. It cannot be
 # called earlier.
-(bash -c "sleep 5; redis-cli -h SERVER_BOOTSTRAP -n OSCI_DBID -p OSCI_PORT hset TEST_USER:CLOUD_NAME:VM:PENDING:UUID cloud_init_vpn $VPNIP" &)
+
+# Additionally, we have to check on both the PENDING and Regular object types. The
+# reason being here is that PENDING will have been deleted back when the VM's
+# post_attach operations have already completed and CloudBench will have already
+# populated the 'real' object, in which case we have to update that object as well.
+(bash -c "sleep 5; redis-cli -h SERVER_BOOTSTRAP -n OSCI_DBID -p OSCI_PORT hset TEST_USER:CLOUD_NAME:VM:PENDING:UUID cloud_init_vpn $VPNIP; exists=\$(redis-cli --raw -h SERVER_BOOTSTRAP -n OSCI_DBID -p OSCI_PORT hexists TEST_USER:CLOUD_NAME:VM:UUID cloud_init_vpn); if [ \$exists == 1 ] ; then redis-cli -h SERVER_BOOTSTRAP -n OSCI_DBID -p OSCI_PORT hset TEST_USER:CLOUD_NAME:VM:UUID cloud_init_vpn $VPNIP; redis-cli -h SERVER_BOOTSTRAP -n OSCI_DBID -p OSCI_PORT hset TEST_USER:CLOUD_NAME:VM:UUID prov_cloud_ip $VPNIP; fi" &)
 
 # Run cloudbench's cloud-agnostic userdata later. Backwards compatible with VPN_ONLY = False
 (/tmp/userscript.sh &)


### PR DESCRIPTION
So, I'm not all that proud of this patch, but I had a hard time thinking of a better solution.

While floating IPs and private IPs stay the same, VPN addresses can (and do) change a lot.

On the orchestrator-side, we already have solutions for this in place that allow the orchestrator
to update it's IP address on-the-fly in case your laptop restarts or the connection resets.

But, on the VM-side, if a VPN connection resets, you're SOL without this patch.

The most important part of this patch is not just the VM-side that updates Redis with the
new IP, but really is the SSH-side of this which *dynamically* contacts Redis to get the
most recently-known IP address before each attempt to retry an SSH command.

Patching the retry support was not so straight forward: Now, instead of embedding the IP
address into the SSH command, we lookup that IP on-the-fly each time the ProcessManagement
code needs to repeat the command.

So, it's a little messy, but I tested it quite a bit and it seems stable.

I'm happy to re-work the patch a little bit if it needs any additional cleanups.