### PR TITLE
Ability to automatically build qcow2 (kvm/qemu) images

### DIFF
--- a/kvm-qemu/base/centos_commands
+++ b/kvm-qemu/base/centos_commands
@@ -1,0 +1,38 @@
+install  openssh-server,passwd,sudo,rsync,git,wget,unzip
+root-password password:temp4now
+edit /etc/ssh/sshd_config:s/PermitRootLogin without-password/PermitRootLogin yes/
+#upload REPLACE_PATH/base/extra_nic.cfg:/etc/network/interfaces.d/extra_nic.cfg
+upload REPLACE_PATH/base/rc.local:/etc/rc.local
+
+chmod 0755:/etc/rc.local
+
+run-command useradd -m -p "$1$1rCJhvTo$nIoKRh4zdGdnk0Dntsdnq/" -s /bin/bash ubuntu
+run-command useradd -m -p "$1$1rCJhvTo$nIoKRh4zdGdnk0Dntsdnq/" -s /bin/bash fedora; 
+run-command useradd -m -p "$1$1rCJhvTo$nIoKRh4zdGdnk0Dntsdnq/" -s /bin/bash REPLACE_USERNAME
+
+run-command echo 'ubuntu  ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers
+run-command echo 'fedora  ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers
+run-command echo 'REPLACE_USERNAME  ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+password ubuntu:password:temp4now
+password fedora:password:temp4now
+password REPLACE_USERNAME:password:temp4now
+
+run-command ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa; touch /root/.ssh/authorized_keys; chmod 644 /root/.ssh/authorized_keys
+
+run-command mkdir -p /home/ubuntu/.ssh/
+run-command ssh-keygen -q -t rsa -N '' -f /home/ubuntu/.ssh/id_rsa
+run-command touch /home/ubuntu/.ssh/authorized_keys; chmod 644 /home/ubuntu/.ssh/authorized_keys; chown -R ubuntu:ubuntu /home/ubuntu/
+
+run-command mkdir -p /home/fedora/.ssh/
+run-command ssh-keygen -q -t rsa -N '' -f /home/fedora/.ssh/id_rsa
+run-command touch /home/fedora/.ssh/authorized_keys; chmod 644 /home/fedora/.ssh/authorized_keys; chown -R fedora:fedora /home/fedora/
+
+run-command git clone https://github.com/ibmcb/cbtool.git
+run-command mv /cbtool /home/REPLACE_USERNAME
+
+run-command mkdir -p /home/REPLACE_USERNAME/.ssh/
+run-command ssh-keygen -q -t rsa -N '' -f /home/REPLACE_USERNAME/.ssh/id_rsa
+run-command touch /home/REPLACE_USERNAME/.ssh/authorized_keys; chmod 644 /home/REPLACE_USERNAME/.ssh/authorized_keys; chown -R REPLACE_USERNAME:REPLACE_USERNAME /home/REPLACE_USERNAME/
+
+run-command cd /home/REPLACE_USERNAME/cbtool; git checkout REPLACE_BRANCH

--- a/kvm-qemu/base/extra_nic.cfg
+++ b/kvm-qemu/base/extra_nic.cfg
@@ -1,0 +1,2 @@
+auto eth1
+iface eth1 inet dhcp

--- a/kvm-qemu/base/fixdefaultgw.service
+++ b/kvm-qemu/base/fixdefaultgw.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Fix Default Route
+After=network.target
+After=systemd-user-sessions.service
+After=network-online.target
+
+[Service]
+User=root
+Type=forking
+ExecStart=/usr/local/bin/fixdefaultgw.sh
+TimeoutSec=30
+Restart=on-failure
+RestartSec=30
+StartLimitInterval=350
+StartLimitBurst=10
+
+[Install]
+WantedBy=multi-user.target

--- a/kvm-qemu/base/fixdefaultgw.sh
+++ b/kvm-qemu/base/fixdefaultgw.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+NR_VNICS=$(ip addr | grep -v lo | grep -v virbr | grep -v docker | grep -v tun | grep mtu | wc -l)
+
+if [[ $NR_VNICS -gt 1 ]]
+then
+    PRIVATE_IP=$(ip -o addr list | grep -v virbr | grep -v docker | grep -v tun | grep -v inet6 | grep inet | awk '{ print $2,$3,$4 }' | grep -E 'inet (192\.168|10\.|172\.1[6789]\.|172\.2[0-9]\.|172\.3[01]\.|90\.90\.)' | awk '{ print $3 }' | cut -d '/' -f 1 | head -n 1)
+    PRIVATE_IF=$(ip -o addr | grep $PRIVATE_IP | awk '{ print $2 }')
+    PUBLIC_IP=$(ip -o addr list | grep -v virbr | grep -v docker | grep -v tun | grep -v 127.0.0.1 | grep -v $PRIVATE_IP | grep -v inet6 | grep inet | awk '{ print $2,$3,$4 }' | awk '{ print $3 }' | cut -d '/' -f 1 | head -n 1)
+    PUBLIC_IF=$(ip -o addr | grep $PUBLIC_IP | awk '{ print $2 }')
+
+    sudo cat /etc/hosts | grep $PRIVATE_IP
+    if [[ $? -ne 0 ]]
+    then
+        echo "$PRIVATE_IP   $(hostname -s)" >> /etc/hosts
+    fi
+
+    netstat -rn | grep UG | grep $PUBLIC_IF
+    COUT=$?
+    DEFAULT_GW=$(netstat -rn | grep UG | awk '{ print $2 }')
+    DEFAULT_IF=$(netstat -rn | grep UG | awk '{ print $8 }')
+
+    if [[ $COUT -ne 0 ]]
+    then
+        echo "Deleting default route with \"root delete default gw $DEFAULT_GW $DEFAULT_IF\"" >> /tmp/fixdefaultgw
+        route delete default gw $DEFAULT_GW $DEFAULT_IF
+        echo "Restarting (ifdown/ifup) $PUBLIC_IF" >> /tmp/fixdefaultgw
+        ifdown $PUBLIC_IF; ifup $PUBLIC_IF
+        netstat -rn | grep UG | grep $PUBLIC_IF
+        DEFAULT_GW=$(netstat -rn | grep UG | awk '{ print $2 }')
+        DEFAULT_IF=$(netstat -rn | grep UG | awk '{ print $8 }')        
+        if [[ $? -eq 0 ]]
+        then
+            echo "Default GW ($DEFAULT_GW) is now accessible through the PUBLIC interface ($PUBLIC_IF)" >> /tmp/fixdefaultgw
+        else
+            echo "Something went wrong. Default GW ($DEFAULT_GW) is still specified over the PRIVATE interface ($PRIVATE_IF)" >> /tmp/fixdefaultgw
+            exit 1
+        fi
+    else
+        echo "Default GW ($DEFAULT_GW) was already accessible through the PUBLIC interface ($PUBLIC_IF)" >> /tmp/fixdefaultgw
+    fi
+else
+    echo "Single VNIC. Nothing to be done" >> /tmp/fixdefaultgw    
+fi
+exit 0

--- a/kvm-qemu/base/ubuntu_commands
+++ b/kvm-qemu/base/ubuntu_commands
@@ -1,0 +1,61 @@
+install sudo,rsync,python2.7,git,wget,unzip,python-setuptools,python-pip,python-requests,python-requests-toolbelt
+
+run-command ln -s /usr/bin/python2.7 /usr/bin/python; /bin/true
+edit /etc/default/grub:s/^GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX=\"biosdevname=0 net.ifnames=0\"/
+run-command update-grub
+root-password password:temp4now
+edit /etc/ssh/sshd_config:s/PermitRootLogin without-password/PermitRootLogin yes/
+upload REPLACE_PATH/base/extra_nic.cfg:/etc/network/interfaces.d/extra_nic.cfg
+upload REPLACE_PATH/base/fixdefaultgw.sh:/usr/local/bin/fixdefaultgw.sh
+upload REPLACE_PATH/base/fixdefaultgw.service:/etc/systemd/system/fixdefaultgw.service
+
+chmod 0755:/usr/local/bin/fixdefaultgw.sh
+
+run-command systemctl enable fixdefaultgw
+
+run-command useradd -m -p "$1$1rCJhvTo$nIoKRh4zdGdnk0Dntsdnq/" -s /bin/bash ubuntu
+run-command useradd -m -p "$1$1rCJhvTo$nIoKRh4zdGdnk0Dntsdnq/" -s /bin/bash fedora; 
+run-command useradd -m -p "$1$1rCJhvTo$nIoKRh4zdGdnk0Dntsdnq/" -s /bin/bash REPLACE_USERNAME
+
+run-command echo 'ubuntu  ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers
+run-command echo 'fedora  ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers
+run-command echo 'REPLACE_USERNAME  ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+password ubuntu:password:temp4now
+password fedora:password:temp4now
+password REPLACE_USERNAME:password:temp4now
+
+run-command ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa; 
+upload /home/REPLACE_USERNAME/.ssh/authorized_keys:/root/.ssh/authorized_keys
+run-command touch /root/.ssh/authorized_keys; chmod 644 /root/.ssh/authorized_keys
+
+run-command mkdir -p /home/ubuntu/.ssh/
+run-command ssh-keygen -q -t rsa -N '' -f /home/ubuntu/.ssh/id_rsa
+run-command touch /home/ubuntu/.ssh/authorized_keys
+upload /home/REPLACE_USERNAME/.ssh/authorized_keys:/home/ubuntu/.ssh/authorized_keys
+run-command chmod 644 /home/ubuntu/.ssh/authorized_keys; chown -R ubuntu:ubuntu /home/ubuntu/
+
+run-command mkdir -p /home/fedora/.ssh/
+run-command ssh-keygen -q -t rsa -N '' -f /home/fedora/.ssh/id_rsa
+run-command touch /home/fedora/.ssh/authorized_keys
+upload /home/REPLACE_USERNAME/.ssh/authorized_keys:/home/fedora/.ssh/authorized_keys
+run-command chmod 644 /home/fedora/.ssh/authorized_keys; chown -R fedora:fedora /home/fedora/
+
+run-command git clone https://github.com/ibmcb/cbtool.git
+run-command mv /cbtool /home/REPLACE_USERNAME
+
+run-command mkdir -p /home/REPLACE_USERNAME/.ssh/
+run-command ssh-keygen -q -t rsa -N '' -f /home/REPLACE_USERNAME/.ssh/id_rsa
+run-command touch /home/REPLACE_USERNAME/.ssh/authorized_keys
+upload /home/REPLACE_USERNAME/.ssh/authorized_keys:/home/REPLACE_USERNAME/.ssh/authorized_keys
+run-command chmod 644 /home/REPLACE_USERNAME/.ssh/authorized_keys; chown -R REPLACE_USERNAME:REPLACE_USERNAME /home/REPLACE_USERNAME/
+run-command cd /home/REPLACE_USERNAME/cbtool; git checkout REPLACE_BRANCH
+
+edit /etc/cloud/cloud.cfg:s/name: ubuntu/name: REPLACE_USERNAME/
+edit /etc/cloud/cloud.cfg:s/lock_passwd: True/lock_passwd: False/
+edit /etc/cloud/cloud.cfg:s/gecos: Ubuntu/gecos: Cloudbench/
+
+upload REPLACE_PATH/../configs/cloud_definitions.txt:/home/REPLACE_USERNAME/cbtool/configs/cloud_definitions.txt
+upload REPLACE_PATH/../configs/templates/_gen.txt:/home/REPLACE_USERNAME/cbtool/configs/templates/_gen.txt
+upload REPLACE_PATH/../lib/clouds/gen_cloud_ops.py:/home/REPLACE_USERNAME/cbtool/lib/clouds/gen_cloud_ops.py
+run-command chown -R REPLACE_USERNAME:REPLACE_USERNAME /home/REPLACE_USERNAME/

--- a/kvm-qemu/build_common.sh
+++ b/kvm-qemu/build_common.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+
+CB_KVMQEMU_BIMG_DIR=NONE
+CB_KVMQEMU_UBUNTU_BASE=https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+CB_KVMQEMU_CENTOS_BASE=https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
+CB_DISTROS="ubuntu"
+CB_USERNAME="cbuser"
+CB_BRANCH="experimental"
+CB_WKS="all"
+CB_VERB=''
+CB_BASE_IMAGE_SKIP=0
+CB_NULLWORKLOAD_IMAGE_SKIP=0
+CB_RSYNC=$(ifconfig $(netstat -rn | grep UG | awk '{ print $8 }') | grep "inet " | awk '{ print $2 }' | sed 's/addr://g')-$(sudo netstat -puntl | grep rsync | grep tcp[[:space:]] | awk '{ print $4 }' | cut -d ':' -f 2)-$(whoami)
+    
+if [ $0 != "-bash" ] ; then
+    pushd `dirname "$0"` 2>&1 > /dev/null
+fi
+CB_KVMQEMU_S_DIR=$(pwd)
+if [ $0 != "-bash" ] ; then
+    popd 2>&1 > /dev/null
+fi
+
+CB_USAGE="Usage: $0 -r built image location [-w Workload] [-l CB Username/login] [-b branch] [-o distros] [--skip] [--verbose]"
+
+function download_base_images {
+    echo "##### Downloading latest version of the vanilla cloud images"
+    pushd $CB_KVMQEMU_BIMG_DIR > /dev/null 2>&1
+    for CB_KVMQEMU_IMG in $CB_KVMQEMU_DISTROS_IMG_LIST
+    do
+        wget -N $CB_KVMQEMU_IMG
+    done
+    echo "##### Done downloading the latest version of the vanilla cloud images"
+    echo
+    popd > /dev/null 2>&1    
+}
+export -f download_base_images
+
+function create_base_images {
+    echo "##### Creating base images.."
+    ERROR=0
+    pushd $CB_KVMQEMU_BIMG_DIR > /dev/null 2>&1
+    for CB_KVMQEMU_IMG in $CB_KVMQEMU_DISTROS_IMG_LIST
+    do
+        CB_KVMQEMU_CIMG_FN=$(echo $CB_KVMQEMU_IMG | rev | cut -d '/' -f 1 | rev)
+        if [[ $(echo $CB_KVMQEMU_CIMG_FN | grep -ci centos) -eq 1 ]]
+        then
+            CB_KVMQEMU_BIMG="centos"
+        else
+            CB_KVMQEMU_BIMG="ubuntu"
+        fi
+	rm -rf cb_base_${CB_KVMQEMU_BIMG}
+	qemu-img create -f qcow2 cb_base_${CB_KVMQEMU_BIMG} 15G
+        virt-resize --expand /dev/sda1 $CB_KVMQEMU_CIMG_FN cb_base_${CB_KVMQEMU_BIMG}
+        #cp -f $CB_KVMQEMU_CIMG_FN cb_base_${CB_KVMQEMU_BIMG}
+        #sudo qemu-img resize cb_base_${CB_KVMQEMU_BIMG} +18G	
+        cp -f $CB_KVMQEMU_S_DIR/base/${CB_KVMQEMU_BIMG}_commands $CB_KVMQEMU_S_DIR/base/${CB_KVMQEMU_BIMG}_commands._processed_
+        sudo sed -i "s^REPLACE_USERNAME^${CB_USERNAME}^g" $CB_KVMQEMU_S_DIR/base/${CB_KVMQEMU_BIMG}_commands._processed_
+        sudo sed -i "s^REPLACE_BRANCH^${CB_BRANCH}^g" $CB_KVMQEMU_S_DIR/base/${CB_KVMQEMU_BIMG}_commands._processed_
+        sudo sed -i "s^REPLACE_PATH^${CB_KVMQEMU_S_DIR}^g" $CB_KVMQEMU_S_DIR/base/${CB_KVMQEMU_BIMG}_commands._processed_
+        	        	
+        virt-customize -a cb_base_${CB_KVMQEMU_BIMG} $CB_VERB --commands-from-file $CB_KVMQEMU_S_DIR/base/${CB_KVMQEMU_BIMG}_commands._processed_
+        COUT=$?
+        let ERROR+=$COUT
+    done
+    if [[ $ERROR -ne 0 ]]
+    then
+        echo "##### Failure while creating base images"
+        exit $ERROR
+    else
+        echo "##### Done creating base images"
+    fi
+    echo
+    popd > /dev/null 2>&1    
+}
+export -f create_base_images
+
+function create_workload_images {
+    CB_WKS_LIST=$1
+    CB_DISTROS_LIST=$2
+    
+    if [[ $CB_DISTROS_LIST == "all" ]]
+    then
+        CB_DISTROS_LIST=ubuntu' 'centos
+    fi
+
+    echo "##### Creating workload images.."
+    ERROR=0
+    pushd $CB_KVMQEMU_BIMG_DIR > /dev/null 2>&1
+
+    for _CB_DISTRO in $CB_DISTROS_LIST
+    do
+        if [[ $CB_WKS_LIST == "all" ]]
+        then
+            CB_WKS_LIST=$(ls $CB_KVMQEMU_S_DIR/../docker/workload/ | grep ${_CB_DISTRO} | grep -v caffe | grep -v rubbos | grep -v rubis | grep -v spark | grep -v speccpu | grep -v specsfs | grep -v specweb | grep -v nullworkload | grep -v ._processed_ | sed "s/Dockerfile-${_CB_DISTRO}_cb_//g")
+        else
+            CB_WKS_LIST=$(ls $CB_KVMQEMU_S_DIR/../docker/workload/ | grep $CB_WKS_LIST | grep ${_CB_DISTRO} | grep -v ._processed_ | sed "s/Dockerfile-${_CB_DISTRO}_cb_//g")
+        fi
+        
+        for _CB_WKS in $CB_WKS_LIST
+        do  
+            if [[ ${_CB_WKS} == "nullworkload" ]]
+            then
+                CB_KVMQEMU_BIMG_FN=cb_base_${_CB_DISTRO}
+            else
+                CB_KVMQEMU_BIMG_FN=cb_nullworkload_${_CB_DISTRO}
+            fi
+            cp -f $CB_KVMQEMU_BIMG_FN cb_${_CB_WKS}_${_CB_DISTRO}
+            CMD="sudo -u $CB_USERNAME /home/$CB_USERNAME/cbtool/install -r workload --wks ${_CB_WKS} --filestore $CB_RSYNC"
+            echo "####### Creating workload image \"cb_${_CB_WKS}_${_CB_DISTRO}\" by executing the command \"$CMD\""
+            virt-customize -m 4096 -a cb_${_CB_WKS}_${_CB_DISTRO} $CB_VERB --run-command "$CMD"
+            COUT=$?
+            if [[ $COUT -ne 0 ]]
+            then
+                echo "############## ERROR: workload image \"cb_${_CB_WKS}_${_CB_DISTRO}\" failed while executing command \"$CMD\""
+            else
+                echo "############## INFO: workload image \"cb_${_CB_WKS}_${_CB_DISTRO}\" built successfully!!!" 
+            fi 
+            let ERROR+=$COUT
+        done
+    done
+
+    if [[ $ERROR -ne 0 ]]
+    then
+        echo "##### Failure while creating workload images"
+        exit $ERROR
+    else
+        echo "##### Done creating workload images"
+    fi
+    echo
+    popd > /dev/null 2>&1    
+}
+export -f create_workload_images
+
+function create_orchestrator_images {
+    CB_DISTROS_LIST=$1
+
+    if [[ $CB_DISTROS_LIST == "all" ]]
+    then
+        CB_DISTROS_LIST=ubuntu' 'centos
+    fi
+
+    echo "##### Creating orchestrator images.."
+    ERROR=0
+    pushd $CB_KVMQEMU_BIMG_DIR > /dev/null 2>&1
+
+    for _CB_DISTRO in $CB_DISTROS_LIST
+    do
+
+        cp -f cb_base_${_CB_DISTRO} cb_orchestrator_${_CB_DISTRO}
+        CMD="sudo -u $CB_USERNAME /home/$CB_USERNAME/cbtool/install -r orchestrator"
+        echo "####### Creating orchestrator image \"cb_orchestrator_${_CB_DISTRO}\" by executing the command \"$CMD\""
+        virt-customize -a cb_orchestrator_${_CB_DISTRO} $CB_VERB --run-command "$CMD"
+        COUT=$?
+        if [[ $COUT -ne 0 ]]
+        then
+            echo "############## ERROR: orchestrator image \"cb_orchestrator_${_CB_DISTRO}\" failed while executing command \"$CMD\""
+        else
+            echo "############## INFO: orchestrator image \"cb_orchestrator_${_CB_DISTRO}\" built successfully!!!"
+        fi
+        let ERROR+=$COUT
+    done
+
+    if [[ $ERROR -ne 0 ]]
+    then
+        echo "##### Failure while creating orchestrator images"
+        exit $ERROR
+    else
+        echo "##### Done creating orchestrator images"
+    fi
+    echo
+    popd > /dev/null 2>&1
+}
+export -f create_orchestrator_images
+

--- a/kvm-qemu/build_orchestrator.sh
+++ b/kvm-qemu/build_orchestrator.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+source ./build_common.sh
+
+CB_USAGE="Usage: $0 -r built image location [-l CB Username/login] [-b branch] [-o distros] [--skip] [--verbose]"
+
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+
+    case $key in
+        -r|--repo)
+        CB_KVMQEMU_BIMG_DIR="$2"
+        shift
+        ;;
+        -r=*|--repo=*)
+        CB_KVMQEMU_BIMG_DIR=$(echo $key | cut -d '=' -f 2)
+        shift
+        ;;
+        -w|--workload)
+        CB_WKS="$2"
+        shift
+        ;;        
+        -w=*|--workload=*)
+        CB_WKS=$(echo $key | cut -d '=' -f 2)
+        shift
+        ;;
+        -l|--login)
+        CB_USERNAME="$2"
+        shift
+        ;;
+        -l=*|--login=*)
+        CB_USERNAME=$(echo $key | cut -d '=' -f 2)
+        shift
+        ;;
+        -b|--branch)
+        CB_BRANCH="$2"
+        shift
+        ;;
+        -b=*|--branch=*)
+        CB_BRANCH=$(echo $key | cut -d '=' -f 2)
+        shift
+        ;;
+        -o|--osdistros)
+        CB_DISTROS="$2"
+        shift
+        ;;
+        -o=*|--osdistros=*)
+        CB_DISTROS=$(echo $key | cut -d '=' -f 2)
+        shift
+        ;;
+        --rsync)
+        CB_RSYNC="$2"
+        shift
+        ;;
+        --rsync=*)
+        CB_RSYNC=$(echo $key | cut -d '=' -f 2)
+        shift
+        ;;
+        --skip)
+        CB_BASE_IMAGE_SKIP=1
+        CB_NULLWORKLOAD_IMAGE_SKIP=1        
+        ;;                                                 
+        -v|--verbose)
+        CB_VERB='-v'
+        ;;
+        -h|--help)
+        echo $CB_USAGE
+        shift
+        ;;
+        *)
+                # unknown option
+        ;;
+        esac
+        shift
+done
+
+if [[ $CB_KVMQEMU_BIMG_DIR == "NONE" ]]
+then
+    echo $CB_USAGE
+    exit 1
+fi
+
+if [[ $CB_DISTROS == "ubuntu" ]]
+then
+    CB_KVMQEMU_DISTROS_IMG_LIST=$CB_KVMQEMU_UBUNTU_BASE
+elif [[ $CB_DISTROS == "centos" ]]
+then
+    CB_KVMQEMU_DISTROS_IMG_LIST=$CB_KVMQEMU_CENTOS_BASE
+elif [[ $CB_DISTROS == "all" ]]
+then
+    CB_KVMQEMU_DISTROS_IMG_LIST=$CB_KVMQEMU_UBUNTU_BASE' '$CB_KVMQEMU_CENTOS_BASE
+fi
+
+if [[ $CB_BASE_IMAGE_SKIP -eq 0 ]]
+then
+    download_base_images
+    create_base_images
+fi
+
+create_orchestrator_images $CB_DISTROS

--- a/kvm-qemu/build_workloads.sh
+++ b/kvm-qemu/build_workloads.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+source ./build_common.sh
+
+CB_USAGE="Usage: $0 -r built image location [-w Workload] [-l CB Username/login] [-b branch] [-o distros] [--skip] [--verbose]"
+
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+
+    case $key in
+        -r|--repo)
+        CB_KVMQEMU_BIMG_DIR="$2"
+        shift
+        ;;
+        -r=*|--repo=*)
+        CB_KVMQEMU_BIMG_DIR=$(echo $key | cut -d '=' -f 2)
+        shift
+        ;;
+        -w|--workload)
+        CB_WKS="$2"
+        shift
+        ;;        
+        -w=*|--workload=*)
+        CB_WKS=$(echo $key | cut -d '=' -f 2)
+        shift
+        ;;
+        -l|--login)
+        CB_USERNAME="$2"
+        shift
+        ;;
+        -l=*|--login=*)
+        CB_USERNAME=$(echo $key | cut -d '=' -f 2)
+        shift
+        ;;
+        -b|--branch)
+        CB_BRANCH="$2"
+        shift
+        ;;
+        -b=*|--branch=*)
+        CB_BRANCH=$(echo $key | cut -d '=' -f 2)
+        shift
+        ;;
+        -o|--osdistros)
+        CB_DISTROS="$2"
+        shift
+        ;;
+        -o=*|--osdistros=*)
+        CB_DISTROS=$(echo $key | cut -d '=' -f 2)
+        shift
+        ;;
+        --rsync)
+        CB_RSYNC="$2"
+        shift
+        ;;
+        --rsync=*)
+        CB_RSYNC=$(echo $key | cut -d '=' -f 2)
+        shift
+        ;;
+        --skip)
+        CB_BASE_IMAGE_SKIP=1
+        CB_NULLWORKLOAD_IMAGE_SKIP=1        
+        ;;                                                 
+        -v|--verbose)
+        CB_VERB='-v'
+        ;;
+        -h|--help)
+        echo $CB_USAGE
+        shift
+        ;;
+        *)
+                # unknown option
+        ;;
+        esac
+        shift
+done
+
+if [[ $CB_KVMQEMU_BIMG_DIR == "NONE" ]]
+then
+    echo $CB_USAGE
+    exit 1
+fi
+
+if [[ $CB_DISTROS == "ubuntu" ]]
+then
+    CB_KVMQEMU_DISTROS_IMG_LIST=$CB_KVMQEMU_UBUNTU_BASE
+elif [[ $CB_DISTROS == "centos" ]]
+then
+    CB_KVMQEMU_DISTROS_IMG_LIST=$CB_KVMQEMU_CENTOS_BASE
+elif [[ $CB_DISTROS == "all" ]]
+then
+    CB_KVMQEMU_DISTROS_IMG_LIST=$CB_KVMQEMU_UBUNTU_BASE' '$CB_KVMQEMU_CENTOS_BASE
+fi
+
+if [[ $CB_BASE_IMAGE_SKIP -eq 0 ]]
+then
+    download_base_images
+    create_base_images
+fi
+
+if [[ $CB_NULLWORKLOAD_IMAGE_SKIP -eq 0 ]]
+then
+    create_workload_images nullworkload $CB_DISTROS
+fi
+
+if [[ $(echo $CB_WKS | grep -c none) -eq 0 ]]
+then 
+    create_workload_images $CB_WKS $CB_DISTROS
+fi


### PR DESCRIPTION
This commit brings the ability to automatically create kvm-qemu images
(both Orchestrator and Workloads). It relies heavily on a recent version
of the utility `virt-customize` (libguestfs 1.34).
A whole set of Workload and Orchestrator images were created and fully
tested through regression (real application) test. Will add
documentation on the wiki as soon as this commit is merged.