### PR TITLE
Define alias for ISAs other than x86_64 and ppc64le

### DIFF
--- a/docker/build_common.sh
+++ b/docker/build_common.sh
@@ -50,13 +50,15 @@ function cb_docker_build {
         CB_ARCH1=x86_64
         CB_ARCH2=x86-64
         CB_ARCH3=amd64
-    fi
-
-    if [[ ${_CB_ARCH} == "ppc64le" ]]
+    elif [[ ${_CB_ARCH} == "ppc64le" ]]
     then
         CB_ARCH1=ppc64le
         CB_ARCH2=ppc64
         CB_ARCH3=ppc64
+    else
+        CB_ARCH1=$CB_ARCH
+        CB_ARCH2=$CB_ARCH
+        CB_ARCH3=$CB_ARCH
     fi                        
 
     CB_ACTUAL_SQUASH=''

--- a/lib/auxiliary/dependencies.py
+++ b/lib/auxiliary/dependencies.py
@@ -881,11 +881,14 @@ def dependency_checker_installer(hostname, depsdict, username, operation, option
             depsdict["carch1"] = "x86_64"           
             depsdict["carch2"] = "x86-64"
             depsdict["carch3"] = "amd64"
-
-        if depsdict["carch"] == "ppc64le" :
+        elif depsdict["carch"] == "ppc64le" :
             depsdict["carch1"] = "ppc64le"           
             depsdict["carch2"] = "ppc64"
             depsdict["carch3"] = "ppc64"
+        else:
+            depsdict["carch1"] = "aarch64"
+            depsdict["carch2"] = "aarch64"
+            depsdict["carch3"] = "aarch64"
                         
         _missing_dep = []
         _dep_list = [0] * 5000


### PR DESCRIPTION
CBTOOL install script defines aliases for x86_64 and ppc64le and assume
they are available. That causes the install script aborts with KeyError
excpetion on aarch64. The change fixes this by adding default values for
all other ISAs.

Note the change just makes sure the variables are defined, it doesn't
guarantee their values are useful. I don't think this is an issue
because for the few dependencies that reference those variables, they
don't provide binary for architectures like aarch64, so user has to
customize configuration file anyway.