### PR TITLE
Libcloud-based adapter for OpenStack.

### DIFF
--- a/configs/templates/_os.txt
+++ b/configs/templates/_os.txt
@@ -1,0 +1,177 @@
+[USER-DEFINED]
+OS_ACCESS = AUTO
+OS_CREDENTIALS = need_to_be_configured_by_user
+OS_KEY_NAME = cbtool_rsa
+OS_SECURITY_GROUPS = need_to_be_configured_by_user
+OS_INITIAL_VMCS = need_to_be_configured_by_user
+OS_SSH_KEY_NAME = cbtool_rsa
+OS_LOGIN = need_to_be_configured_by_user
+OS_NETNAME = need_to_be_configured_by_user
+
+# PEBCAK documentation for the Wizard and CLI
+OS_ACCESS_DOC = Leave it as AUTO. This information will be extracted from the "rc" file.
+OS_ACCESS_DEFAULT = AUTO
+OS_CREDENTIALS_DOC = Comma-separated list of account "rc" files to use. This field should be in the form of tag1:file1,tag2:file2,... where the tag is an arbitrary name chosen by you to identify which account the "rc" file came from.
+OS_CREDENTIALS_DEFAULT = tenant1:~/adminrc
+OS_KEY_NAME_DOC = Please enter the OpenStack key used to login\nto your VMs as root. This key needs to be generated in\nthe OpenStack user interface before starting the tool.
+OS_KEY_NAME_DEFAULT = some_key_name 
+OS_SECURITY_GROUPS_DOC = Please enter the security group used in\nyour OpenStack vms. This group needs to be created\nin the OpenStack user interface before\nstarting the tool.
+OS_SECURITY_GROUPS_DEFAULT = default 
+OS_LOGIN_DOC = $LOGIN_DOC
+OS_LOGIN_DEFAULT = some_login_name
+OS_SSH_KEY_NAME_DOC = $SSH_KEY_NAME_DOC
+OS_SSH_KEY_NAME_DEFAULT = id_rsa.private
+OS_INITIAL_VMCS_DOC = $INITIAL_VMCS_DOC 
+OS_INITIAL_VMCS_DEFAULT = RegionOne
+OS_NETNAME_DOC = "Please enter the name of the network that will connect all created VMs"
+OS_NETNAME_DEFAULT = private
+
+[SPACE : OS_CLOUDCONFIG ]
+SSH_KEY_NAME = $OS_SSH_KEY_NAME
+
+[MON_DEFAULTS : OS_CLOUDCONFIG ]
+COLLECT_FROM_HOST = $False # requires ganglia installation on hypervisor
+COLLECT_FROM_GUEST = $False
+
+[VMC_DEFAULTS : OS_CLOUDCONFIG]
+ACCESS = $OS_ACCESS
+CREDENTIALS = $OS_CREDENTIALS
+SECURITY_GROUPS = $OS_SECURITY_GROUPS
+KEY_NAME = $OS_KEY_NAME
+INITIAL_VMCS = $OS_INITIAL_VMCS
+ADDITIONAL_DISCOVERY = $Empty
+MODIFY_HOST_NAMES = $False
+MIGRATE_SUPPORTED = $False
+PROTECT_SUPPORTED = $False
+
+[VM_DEFAULTS : OS_CLOUDCONFIG]
+ACCESS = $OS_ACCESS
+CREDENTIALS = $OS_CREDENTIALS
+KEY_NAME = $OS_KEY_NAME
+SECURITY_GROUPS = $OS_SECURITY_GROUPS
+CLOUD_MAC = $True
+CAPTURE_SUPPORTED = $True
+RUNSTATE_SUPPORTED = $True
+RESIZE_SUPPORTED = $False
+LOGIN = $OS_LOGIN
+SSH_KEY_NAME = $OS_SSH_KEY_NAME
+CHECK_BOOT_STARTED = poll_cloud
+# Other methods could be used to check if a VM *STARTED* booting
+#CHECK_BOOT_STARTED = subscribe_on_starting
+CHECK_BOOT_COMPLETE = tcp_on_22
+# Other methods could be used to check if a VM *FINISHED* booting
+#CHECK_BOOT_COMPLETE = subscribe_on_booting
+#CHECK_BOOT_COMPLETE = wait_for_0
+NETNAME = $OS_NETNAME
+TENANT = default
+PROJECT = default
+JUMPHOST_ROLE = tinyvm
+JUMPHOST_SIZE = m1.tiny
+SIZE = from_vm_template
+CREATE_LB = $false
+CGROUPS_BASE_DIR = /sys/fs/cgroup/
+HOSTNAME_KEY = cloud_vm_name
+FLOATING_POOL = $Empty
+ALWAYS_CREATE_FLOATING_IP = $True
+LEAVE_INSTANCE_ON_FAILURE = $False
+FORCE_FAILURE = $False
+DISABLE_TIMESYNC = $False
+AVAILABILITY_ZONE = $Empty
+BOOT_VOLUME_IMAGEID1_INSTANCE = None
+FLAVOR_INSTANCE = None
+IMAGE_PREFIX = $EMPTY
+IMAGE_SUFFIX = $EMPTY
+
+[AI_DEFAULTS : OS_CLOUDCONFIG]
+ATTACH_PARALLELISM = 10
+CAPTURE_SUPPORTED = $True
+RUNSTATE_SUPPORTED = $True
+RESIZE_SUPPORTED = $True
+LOGIN = $OS_LOGIN
+SSH_KEY_NAME = $OS_SSH_KEY_NAME
+CREDENTIALS = $OS_CREDENTIALS
+KEY_NAME = $OS_KEY_NAME
+NETNAME = $OS_NETNAME
+TENANT = default
+PROJECT = default
+FLOATING_POOL = $Empty
+CREATE_LB = $false
+ALWAYS_CREATE_FLOATING_IP = $True
+DONT_START_QEMU_SCRAPER = $True
+
+[AIDRS_DEFAULTS : OS_CLOUDCONFIG]
+LOGIN = $OS_LOGIN
+SSH_KEY_NAME = $OS_SSH_KEY_NAME
+
+[VMCRS_DEFAULTS : OS_CLOUDCONFIG]
+LOGIN = $OS_LOGIN
+SSH_KEY_NAME = $OS_SSH_KEY_NAME
+
+[FIRS_DEFAULTS : OS_CLOUDCONFIG]
+LOGIN = $OS_LOGIN
+SSH_KEY_NAME = $OS_SSH_KEY_NAME
+
+[VM_TEMPLATES : OS_CLOUDCONFIG]
+ACMEAIR = size:m1.medium, imageid1:cb_acmeair 
+APACHE = size:m1.medium, imageid1:cb_wrk
+BONNIE = size:m1.medium, imageid1:cb_bonnie
+BTEST = size:m1.medium, imageid1:cb_btest
+CASSANDRA = size:m1.medium, imageid1:cb_ycsb
+CHECK = size:m1.tiny, imageid1:to_replace
+CLIENT_IBM_DAYTRADER = size:m1.medium, imageid1:cb_daytrader
+CLIENT_OPEN_DAYTRADER = size:m1.medium, imageid1:cb_open_daytrader
+CLIENT_TRADELITE = size:m1.medium, imageid1:cb_tradelite
+CLIENT_WINDOWS = size:m1.medium, imageid1:cb_windows
+CN_HPC = size:m1.medium, imageid1:cb_hpcc
+COREMARK = size:m1.tiny, imageid1:cb_coremark
+DB2 = size:m1.medium, lb_size:m1.large, imageid1:cb_daytrader
+DDGEN = size:m1.medium, imageid1:cb_ddgen
+DRIVER_COREMARK = size:m1.tiny, imageid1:cb_coremark
+DRIVER_DAYTRADER = size:m1.medium, imageid1:cb_daytrader
+DRIVER_FILEBENCH = size:m1.medium, imageid1:cb_filebench
+DRIVER_FIO = size:m1.medium, imageid1:cb_fio
+DRIVER_HADOOP = size:m1.tiny, imageid1:cb_hadoop
+DRIVER_NETPERF = size:m1.tiny, imageid1:cb_hadoop
+DRIVER_TRADELITE = size:m1.medium, imageid1:cb_tradelite
+FEN_HPC = size:m1.medium, imageid1:cb_hpcc
+FILEBENCH = size:m1.small, imageid1:cb_filebench
+FIO = size:m1.medium, imageid1:cb_fio
+GERONIMO = size:m1.medium, imageid1:cb_open_daytrader
+GIRAPHMASTER = size:m1.small, imageid1:cb_giraph
+GIRAPHSLAVE = size:m1.medium, imageid1:cb_giraph
+HADOOPMASTER = size:m1.small, imageid1:cb_hadoop
+HADOOPSLAVE = size:m1.medium, imageid1:cb_hadoop
+IPERFCLIENT = size:m1.small, imageid1:cb_iperf
+IPERFSERVER = size:m1.small, imageid1:cb_iperf
+LB = size:m1.medium, imageid1:cb_nullworkload
+LIBERTY = size:m1.medium, imageid1:cb_acmeair
+LINPACK = size:m1.medium, imageid1:cb_linpack
+MEMTIER = size:m1.medium, imageid1:cb_memtier
+MONGO_CFG_SERVER = size:m1.small, imageid1:cb_ycsb
+MONGODB = size:m1.medium, imageid1:cb_ycsb
+MONGOS = size:m1.large, imageid1:cb_ycsb
+MULTICHASE = size:m1.small, imageid1:cb_multichase
+MYSQL = size:m1.medium, lb_size:m1.large, imageid1:cb_open_daytrader
+NETCLIENT = size:m1.small, imageid1:cb_netperf
+NETSERVER = size:m1.small, imageid1:cb_netperf
+NUTTCPCLIENT = size:m1.small, imageid1:cb_nuttcp
+NUTTCPSERVER = size:m1.small, imageid1:cb_nuttcp
+OLDISIMDRIVER = size:m1.small, imageid1:cb_oldisim
+OLDISIMLB = size:m1.small, imageid1:cb_oldisim
+OLDISIMLEAF = size:m1.small, imageid1:cb_oldisim
+OLDISIMROOT = size:m1.small, imageid1:cb_oldisim
+POSTMARK = size:m1.medium, imageid1:cb_postmark
+REDIS = size:m1.medium, imageid1:cb_ycsb
+SCIMARK = size:m1.small, imageid1:cb_scimark
+SEED = size:m1.medium, imageid1:cb_ycsb
+SPECJBB = size:m1.medium, imageid1:cb_specjbb
+SYSBENCH = size:m1.medium, imageid1:cb_sysbench
+TINYVM = size:m1.tiny, imageid1:cb_nullworkload
+UNIXBENCH = size:m1.medium, imageid1:cb_unixbench
+WAS = size:m1.medium, imageid1:cb_daytrader
+WINDOWS = size:m1.medium, imageid1:cb_windows
+WRK = size:m1.medium, imageid1:cb_wrk
+XPINGRECEIVER = size:m1.small, imageid1:cb_xping
+XPINGSENDER = size:m1.small, imageid1:cb_xping
+YATINYVM = size:m1.tiny, imageid1:cb_nullworkload
+YCSB = size:m1.medium, imageid1:cb_ycsb

--- a/lib/clouds/os_cloud_ops.py
+++ b/lib/clouds/os_cloud_ops.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python
+
+#/*******************************************************************************
+# Copyright (c) 2018 IBM Corp.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/*******************************************************************************
+
+#/*******************************************************************************
+# Copyright (c) 2015 DigitalOcean, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#/*******************************************************************************
+
+'''
+    Created on Jan 30, 2018
+    OpenStack Object Operations Library
+    @author: Marcio Silva, Michael R. Hines
+'''
+
+from time import time
+
+from lib.auxiliary.code_instrumentation import trace, cbdebug, cberr, cbwarn, cbinfo, cbcrit
+from lib.auxiliary.data_ops import is_number
+from libcloud_common import LibcloudCmds
+
+from shared_functions import CldOpsException
+
+#from libcloud.compute.drivers.azure import ConfigurationSet,ConfigurationSetInputEndpoint
+
+class OsCmds(LibcloudCmds) :
+    @trace
+    def __init__ (self, pid, osci, expid = None) :
+        LibcloudCmds.__init__(self, pid, osci, expid = expid, \
+                              provider = "OPENSTACK", \
+                              num_credentials = 1, \
+                              use_ssh_keys = True, \
+                              use_volumes = True, \
+                              use_networks = True, \
+                              use_security_groups = True, \
+                              use_floating_ips = True, \
+                              use_public_ips = False, \
+                              use_get_image = True, \
+                              verify_ssl = False, \
+                              tldomain = "openstack.org" \
+                             )
+
+    # All clouds based on libcloud should define this function.
+    # It performs the initial libcloud setup.
+    @trace
+    def get_libcloud_driver(self, libcloud_driver, tenant, access_token) :
+        '''
+        TBD
+        '''
+        
+        _access_url = "auto"
+        _auth_version = '3.x_password'
+        _endpoint_type = "publicURL"
+        _region = "auto"
+        _username = "auto"
+        _password = "auto"
+        _tenant = "auto"
+        _project_name = None
+        _cacert = None
+        _insecure = False
+        _user_domain_id = "default"
+        _project_domain_id = "default"
+        _domain_name = "Default"
+
+        if not self.connauth_pamap :
+            self.connauth_pamap = self.parse_cloud_connection_file(access_token)
+
+        if "OS_AUTH_URL" in self.connauth_pamap :
+            _access_url = self.connauth_pamap["OS_AUTH_URL"]
+
+        if "OS_ENDPOINT_TYPE" in self.connauth_pamap :
+            _endpoint_type = self.connauth_pamap["OS_ENDPOINT_TYPE"]
+
+        if "OS_REGION_NAME" in self.connauth_pamap :
+            _region = self.connauth_pamap["OS_REGION_NAME"]
+
+        if "OS_USERNAME" in self.connauth_pamap :
+            _username = self.connauth_pamap["OS_USERNAME"]
+
+        if "OS_PASSWORD" in self.connauth_pamap :
+            _password = self.connauth_pamap["OS_PASSWORD"]
+
+        if "OS_TENANT_NAME" in self.connauth_pamap :
+            _tenant = self.connauth_pamap["OS_TENANT_NAME"]
+
+        if "OS_PROJECT_NAME" in self.connauth_pamap :
+            _project_name = self.connauth_pamap["OS_PROJECT_NAME"]
+
+        if "OS_CACERT" in self.connauth_pamap :
+            _cacert = self.connauth_pamap["OS_CACERT"]
+
+        if "OS_INSECURE" in self.connauth_pamap :
+            if self.connauth_pamap["OS_INSECURE"] == "1" :
+                _insecure = True
+
+        if "OS_PROJECT_DOMAIN_ID" in self.connauth_pamap :
+            _project_domain_id = self.connauth_pamap["OS_PROJECT_DOMAIN_ID"]
+
+        if "OS_DOMAIN_NAME" in self.connauth_pamap :
+            _domain_name = self.connauth_pamap["OS_DOMAIN_NAME"]
+
+        if "OS_USER_DOMAIN_ID" in self.connauth_pamap :
+            _user_domain_id = self.connauth_pamap["OS_USER_DOMAIN_ID"]
+
+        if "OS_USER_DOMAIN_NAME" in self.connauth_pamap :
+            _user_domain_name = self.connauth_pamap["OS_USER_DOMAIN_NAME"]
+
+        _access_url = _access_url.replace("/v2.0/",'').replace("/v3/",'').replace("/identity",'')
+
+        self.access = _access_url + '-' + _endpoint_type
+
+        if not _project_name :
+            _project_name = _username
+
+        driver = libcloud_driver(_username, \
+                                 _password, \
+                                 ex_force_auth_version = _auth_version, \
+                                 ex_force_auth_url = _access_url, \
+                                 ex_force_service_type='compute', \
+                                 ex_force_service_region = _region, \
+                                 ex_tenant_name = _tenant, \
+                                 ex_project_name = _project_name, \
+                                 ex_project_domain_id =  _project_domain_id, \
+                                 ex_user_domain_id = _user_domain_id, \
+                                 ex_domain_name = _domain_name)
+
+        _msg = "Libcloud connection code is \"python -c 'from libcloud.compute."
+        _msg += "providers import get_driver; from libcloud.compute.types import"
+        _msg += " Provider; cls = get_driver(Provider.OPENSTACK); con = "
+        _msg += "cls(\"" + _username + "\", " + "\"REPLACE_PASSWORD\"" + ", "
+        _msg += "ex_force_auth_version = \"" + _auth_version + "\", "
+        _msg += "ex_force_auth_url = \"" + _access_url + "\", "
+        _msg += "ex_force_service_type = \"" + "compute" + "\", "
+        _msg += "ex_force_service_region = \"" + _region + "\", "
+        _msg += "ex_tenant_name = \"" + _tenant + "\", "
+        _msg += "ex_project_name = \"" + _project_name + "\", "
+        _msg += "ex_project_domain_id = \"" + _project_domain_id + "\", "
+        _msg += "ex_user_domain_id = \"" + _user_domain_id + "\")'"
+        cbdebug(_msg, True)
+
+        return driver
+
+    @trace
+    def extra_vmc_setup(self, vmc_name, vmc_defaults, vm_defaults, vm_templates, _local_conn) :
+        '''
+        TBD
+        '''
+        if "OS_TENANT_NAME" in self.connauth_pamap :
+            vm_defaults["tenant_from_rc"] = self.connauth_pamap["OS_TENANT_NAME"]
+
+        vm_defaults["access"] = self.access
+
+        vmc_defaults["access"] = self.access
+        
+        return True
+
+    @trace
+    def is_cloud_image_uuid(self, imageid) :
+        '''
+        TBD
+        '''
+        if len(imageid) == 36 and imageid.count('-') == 4 :
+            return True
+
+        return False
+
+    @trace            
+    def create_ssh_key(self, vmc_name, key_name, key_type, key_contents, key_fingerprint, vm_defaults, connection) :
+        '''
+        TBD
+        '''
+        connection.import_key_pair_from_string(key_name, key_type + ' ' + key_contents + " cbtool@orchestrator")        
+        return True
+    
+    @trace
+    def pre_vmcreate_process(self, obj_attr_list, extra, keys) :
+        '''
+        TBD
+        '''
+        
+        obj_attr_list["region"] = obj_attr_list["vmc_name"]
+
+        for _location in LibcloudCmds.locations :
+            if _location.id == obj_attr_list["region"] :
+                obj_attr_list["libcloud_location_inst"] = _location
+                break
+
+        _mark_a = time()
+        _security_groups = []
+
+        for _secgrp in LibcloudCmds.security_groups :
+            for _security_group in obj_attr_list["security_groups"].split(',') :
+                if _secgrp.name == obj_attr_list["security_groups"] :
+                    _security_groups.append(_secgrp)
+        self.annotate_time_breakdown(obj_attr_list, "get_secgrp_time", _mark_a)
+
+        _mark_a = time()
+        _networks = []
+        for _network in LibcloudCmds.networks :
+            if _network.name == obj_attr_list["run_netname"] :
+                if _network not in _networks :
+                    _networks.append(_network)
+
+            if _network.name == obj_attr_list["prov_netname"] :
+                if _network not in _networks :
+                    _networks.append(_network)
+        self.annotate_time_breakdown(obj_attr_list, "get_net_time", _mark_a)
+
+        obj_attr_list["availability_zone"] = "none"
+
+        obj_attr_list["libcloud_call_type"] = "create_node_with_keyword_arguments_only"
+
+        self.vmcreate_kwargs["name"] = obj_attr_list["cloud_vm_name"]
+        self.vmcreate_kwargs["size"] = obj_attr_list["libcloud_size_inst"]
+        self.vmcreate_kwargs["image"] =  obj_attr_list["libcloud_image_inst"]        
+        self.vmcreate_kwargs["ex_security_groups"] = _security_groups
+        self.vmcreate_kwargs["ex_userdata"] = obj_attr_list["userdata"]
+        self.vmcreate_kwargs["ex_config_drive"] = obj_attr_list["config_drive"]        
+        self.vmcreate_kwargs["ex_keyname"] = keys[0]
+        self.vmcreate_kwargs["networks"] = _networks       
+        self.vmcreate_kwargs["ex_metadata"] =  {}
+        
+        if "cloud_floating_ip_uuid" in obj_attr_list :
+            self.vmcreate_kwargs["ex_metadata"]["cloud_floating_ip_uuid"] = obj_attr_list["cloud_floating_ip_uuid"]
+        if "cloud_floating_ip" in obj_attr_list :            
+            self.vmcreate_kwargs["ex_metadata"]["cloud_floating_ip"] = obj_attr_list["cloud_floating_ip"]
+                
+        return extra
+
+    @trace
+    def get_description(self) :
+        '''
+        TBD
+        '''
+        return "OpenStack"


### PR DESCRIPTION
Keeping up-to-date with changes in the myriad of OpenStack Clients
has been a problem for us for a long time. This update introduces
an alternative adapter for OpenStack clouds, leveraging the work
done on libcloud (OpenStack backend). For now, I propose we let the
two adapters to co-exist, and as we harden and mature this code, we
can obsolete the other adapter.