### PR TITLE
Remove execution on instances

### DIFF
--- a/lib/operations/active_operations.py
+++ b/lib/operations/active_operations.py
@@ -2133,14 +2133,17 @@ class ActiveObjectOperations(BaseObjectOperations) :
                     if not "submitter" in obj_attr_list :
                         if _obj_type == "VM" :
                             if obj_attr_list["prov_cloud_ip"] == obj_attr_list["run_cloud_ip"] :
-                                _ip = "IP address " + obj_attr_list["cloud_ip"]
+                                _ip = "IP address " + obj_attr_list["cloud_ip"] + " (port " + str(obj_attr_list["prov_cloud_port"]) + ")"
                             else :
-                                _ip = "IP addresses " + obj_attr_list["prov_cloud_ip"] + " and " + obj_attr_list["run_cloud_ip"] 
+                                _ip = "IP addresses " + obj_attr_list["prov_cloud_ip"] + " (port " + str(obj_attr_list["prov_cloud_port"]) + ")"+ " and " + obj_attr_list["run_cloud_ip"] 
                         else :
                             _ip = "IP address " + obj_attr_list["cloud_ip"]
 
+                        if _ip.count('-') :
+                            _ip = _ip.split('-')[0]
+                        
                         _msg += " It is ssh-accessible at the " + _ip
-                        _msg += " (" + obj_attr_list["cloud_hostname"] + ")."
+                        _msg += " (hostname is " + obj_attr_list["cloud_hostname"] + ")."
                                                 
                     obj_attr_list["tracking"] = "Attach: success." 
 

--- a/lib/operations/passive_operations.py
+++ b/lib/operations/passive_operations.py
@@ -1754,7 +1754,7 @@ class PassiveObjectOperations(BaseObjectOperations) :
                         cbdebug(_msg, True)
                         if _space_attr_list["tracefile"][0] != "/" :
                             _source = _space_attr_list["base_dir"] + '/' + _space_attr_list["tracefile"]
-                        shutil.copy2(_source, _destination)
+                            shutil.copy2(_source, _destination)
 
                     if str(_logstor_attr_list["just_restarted"]).lower() == "true" :
                         _msg = "This experiment was run right after a flushing of the Log Store."
@@ -2568,6 +2568,7 @@ class PassiveObjectOperations(BaseObjectOperations) :
             _msg = ""
 
             _vm = None
+            _actual_cmd = ''
             
             if not _status :
 
@@ -2587,24 +2588,33 @@ class PassiveObjectOperations(BaseObjectOperations) :
                                                  True, \
                                                  _vm, \
                                                  False)
+                        else :
+                            _actual_cmd += _word + ' ' 
 
                     if not _vm :
-                        True
+                        _proc_man =  ProcessManagement()                                                 
+
                     else :
-                        _ssh_cmd = "ssh -i " + _vm_attr_list["identity"]
+                        _proc_man =  ProcessManagement(hostname = _vm_attr_list["prov_cloud_ip"], \
+                                                       port = _vm_attr_list["prov_cloud_port"], \
+                                                       username = _vm_attr_list["login"], \
+                                                       cloud_name = _vm_attr_list["cloud_name"], \
+                                                       priv_key = _vm_attr_list["identity"])
+                        
+#                        _ssh_cmd = "ssh -i " + _vm_attr_list["identity"]
 
-                        if "ssh_config_file" in _vm_attr_list :
-                            _ssh_cmd += " -F " + _vm_attr_list["ssh_config_file"]
+#                        if "ssh_config_file" in _vm_attr_list :
+#                            _ssh_cmd += " -F " + _vm_attr_list["ssh_config_file"]
 
-                        _ssh_cmd += " -o StrictHostKeyChecking=no"
-                        _ssh_cmd += " -o UserKnownHostsFile=/dev/null" 
-                        _ssh_cmd += " -l " + _vm_attr_list["login"] + ' '
+#                        _ssh_cmd += " -o StrictHostKeyChecking=no"
+#                        _ssh_cmd += " -o UserKnownHostsFile=/dev/null" 
+#                        _ssh_cmd += " -l " + _vm_attr_list["login"] + ' '
 
-                        _cmd = _ssh_cmd + ' ' + _vm_attr_list["prov_cloud_ip"] + " \"" + _cmd.replace(_vm,'') + "\""
+#                        _cmd = _ssh_cmd + ' ' + _vm_attr_list["prov_cloud_ip"] + " \"" + _cmd.replace(_vm,'') + "\""
 
-                    _proc_man =  ProcessManagement()                                                 
-                    print "running shell command: \"" + _cmd + "\"...."
-                    _status, _result_stdout, _result_stderr = _proc_man.run_os_command(_cmd)
+#                    _proc_man =  ProcessManagement()                                                 
+                    print "running shell command: \"" + _actual_cmd + "\"...."
+                    _status, _result_stdout, _result_stderr = _proc_man.run_os_command(_actual_cmd)
                     result_dict = {"stdout": _result_stdout, "stderr": _result_stderr}
  
                     if not _status :

--- a/lib/remote/process_management.py
+++ b/lib/remote/process_management.py
@@ -67,7 +67,7 @@ class ProcessManagement :
     @trace
     def run_os_command(self, cmdline, override_hostname = None, really_execute = True, \
                        debug_cmd = False, raise_exception = True, step = None, \
-                       tell_me_if_stderr_contains = False, port = 22, check_stderr_len = True) :
+                       tell_me_if_stderr_contains = False, port = None, check_stderr_len = True) :
         '''
         TBD
         '''
@@ -81,7 +81,10 @@ class ProcessManagement :
         else :
             _local = False
 
-        _port = port
+        if port :
+            _port = port
+        else :
+            _port = self.port
         
         if _local :
             # This is causing problems, but generally seems kind of wierd anyway.


### PR DESCRIPTION
This update introduces a very useful feature: the ability to use the
CLI/API call `shell` to execute code on instances. The Orchestrator
already knows how to (via ssh) reach any instance. We leverage this
information to instruct it (the Orchestrator) to execute any command
directly on an instance. Here is an illustrative example:

(TESTPLM WALKTHROUGH) shell vm_1 sudo fdisk -l | grep Disk | grep bytes
|
cut -d ' ' -f 2 | sed 's/://g' | sed '$!{:a;N;s/\n/,/;ta}'
running shell command: "sudo fdisk -l | grep Disk | grep bytes | cut -d
' ' -f 2 | sed 's/://g' | sed '$!{:a;N;s/\n/,/;ta}' "....
stdout:
 /dev/vda,/dev/vdb

stderr:
 Warning: Permanently added '[9.2.211.203]:40001' (ECDSA) to the list of
known hosts.
sudo: unable to resolve host cb-msilva-TESTPLM-vm1-check

So, basically, by adding the word `vm_1` as the first parameter after
the `shell` call, the Orchestrator will automatically detect that all
the other parameters refers to commands to be executed remotely on the
instance.