### PR TITLE
Improvements for workload image creation (dynamic configuration)

### DIFF
--- a/configs/templates/internal_options.txt
+++ b/configs/templates/internal_options.txt
@@ -53,7 +53,7 @@ GLOBAL_OBJECT_LIST = setup,logstore,metricstore,filestore,dash_defaults,mon_defa
 GLOBAL_OBJECT_LIST += vpn,space,time,vmc_defaults,vm_defaults,ai_defaults,
 GLOBAL_OBJECT_LIST += aidrs_defaults,vmcrs_defaults,firs_defaults,vm_templates,
 GLOBAL_OBJECT_LIST += ai_templates,aidrs_templates,vmcrs_templates,fi_templates,
-GLOBAL_OBJECT_LIST += firs_templates,query,admission_control,api_defaults,gui_defaults
+GLOBAL_OBJECT_LIST += firs_templates,query,admission_control,api_defaults,gui_defaults,build
 
 [SPACE]
 BASE_DIR = $MAIN_BASE_DIR
@@ -202,6 +202,9 @@ JUMPHOST_LOGIN = auto
 JUMPHOST_NETNAMES = all
 TIME_BREAKDOWN_STEP = 1
 ABORT_AFTER_SSH_UPLOAD_FAILURE = $True
+PREPARE_WORKLOAD = None
+PREPARE_WORKLOAD_NAMES = None
+PREPARE_IMAGE_NAME = None
 
 [AI_DEFAULTS]
 USERNAME = $MAIN_USERNAME

--- a/lib/operations/active_operations.py
+++ b/lib/operations/active_operations.py
@@ -248,6 +248,8 @@ class ActiveObjectOperations(BaseObjectOperations) :
                     _aux = str2dic(cld_attr_lst["vm_templates"][_vm_role])
                     _aux["imageid1"] = cld_attr_lst["vm_defaults"]["image_prefix"].strip() + _aux["imageid1"] + cld_attr_lst["vm_defaults"]["image_suffix"].strip()
                     cld_attr_lst["vm_templates"][_vm_role] = dic2str(_aux)
+
+                self.create_image_build_map(cld_attr_lst)
                     
                 for _vmc_entry in _initial_vmcs :
                     _cld_conn = _cld_ops_class(self.pid, None, None)
@@ -2401,14 +2403,19 @@ class ActiveObjectOperations(BaseObjectOperations) :
                     obj_attr_list["identity"] = obj_attr_list["identity"].replace(obj_attr_list["username"], \
                                                                                   obj_attr_list["login"])
 
-                _msg = "Performing generic VM post_boot configuration on " + obj_attr_list["log_string"] 
-                _msg += ", on IP address "+ obj_attr_list["prov_cloud_ip"] + "..."     
+
+                if str(obj_attr_list["prepare_workload_names"]).lower() != "none" \
+                and str(obj_attr_list["prepare_image_name"]).lower() != "none" :
+                    _msg = "Performing workload (" + obj_attr_list["prepare_workload_names"] 
+                    _msg += ") image build operation on " + obj_attr_list["log_string"]
+                    _msg += ", on IP address "+ obj_attr_list["prov_cloud_ip"] + "..."     
+                else :
+                    _msg = "Performing generic instance post_boot configuration on " + obj_attr_list["log_string"] 
+                    _msg += ", on IP address "+ obj_attr_list["prov_cloud_ip"] + "..."     
                 cbdebug(_msg, selectively_print_message("run_generic_scripts", obj_attr_list))
 
-                _cmd = "~/" + obj_attr_list["remote_dir_name"] + "/scripts/common/cb_post_boot.sh"
-                
                 _status, _result_stdout, _result_stderr = \
-                        _proc_man.retriable_run_os_command(_cmd, obj_attr_list["uuid"], \
+                        _proc_man.retriable_run_os_command(obj_attr_list["generic_post_boot_command"], obj_attr_list["uuid"], \
                                                            really_execute = obj_attr_list["run_generic_scripts"], \
                                                            debug_cmd = obj_attr_list["debug_remote_commands"], \
                                                            total_attempts = int(obj_attr_list["update_attempts"]),\
@@ -2418,7 +2425,8 @@ class ActiveObjectOperations(BaseObjectOperations) :
                                                            port = obj_attr_list["prov_cloud_port"], \
                                                            osci = self.osci, \
                                                            get_hostname_using_key = "prov_cloud_ip"  \
-                                                           )
+                                                           )                   
+
                 _time_mark_ipbc = int(time())
                 if "time_mark_aux" in obj_attr_list :
                     _delay = _time_mark_ipbc - obj_attr_list["time_mark_aux"]
@@ -2440,9 +2448,19 @@ class ActiveObjectOperations(BaseObjectOperations) :
                                                       "generic post-boot script executed")                    
                     obj_attr_list["last_known_state"] = "generic post-boot script executed"
 
-                _msg = "Performed generic VM post_boot configuration on " + obj_attr_list["log_string"] 
-                _msg += ", on IP address "+ obj_attr_list["prov_cloud_ip"] + "..."     
-                cbdebug(_msg)
+                if str(obj_attr_list["prepare_workload_names"]).lower() != "none" \
+                and str(obj_attr_list["prepare_image_name"]).lower() != "none" :
+                    _msg = "Performed workload image build operation on " + obj_attr_list["log_string"]
+                    _msg += ", on IP address "+ obj_attr_list["prov_cloud_ip"] + "."
+                    _msg += "You can now capture this image with \"vmcapture youngest "
+                    _msg += obj_attr_list["image_prefix"].strip() + obj_attr_list["prepare_image_name"]
+                    _msg += obj_attr_list["image_suffix"].strip() + "\" on the CLI\n"
+                    cbdebug(_msg)
+                    print '\n' + _msg                    
+                else :
+                    _msg = "Performed generic VM post_boot configuration on " + obj_attr_list["log_string"] 
+                    _msg += ", on IP address "+ obj_attr_list["prov_cloud_ip"] + "..."     
+                    cbdebug(_msg)
                      
             else :                
                 _status = 0


### PR DESCRIPTION
Workload Image building directly from CLI/API: initial support for
it was introduced a while back, but full use of this feature has
always been limited due to the fact that not all workloads map nicely
to a single image. An example: we us a single image - and thus a single
Dockerfile - for all YCSB workloads, be it MongoDB, Redis and Cassandra.
With the updates made here, CBTOOL now is able to properly map AI types
to Dockerfiles, automatically extracting the correct paramaters to call
the automated installer (just remember, the automated installer parses
the Dockerfiles to figure which commands to execute).

This means that a CLI/API call such as `vmattach check:<BLANKIMG>:
<DEFUSER>:nullworkload:build` will result in the execution of the
 automated installer (i.e., `~/cbtool/install`) with the appropriate
 parameters (i.e., `--role workload --wks nullworkload`).

To further illustrate the somewhat confused point made above: if a
CLI/API call such as `vmattach check:<BLANKIMG>:<DEFUSER>:
cassandra_ycsb:build` is issued, then the paramaters for the
invocation of the automated installer will be `-role workload
--wks nullworkload,redis_ycsb,mongo_ycsb,cassandra_ycsb`.

NOTE: After the instance image creation is complete, the user can proceed to
capture it with the `vmcapture` call

Dyamic Workload configuration during deployment (using unconfigured
images): the very same mechanism explained above allows the user to
deploy fully functional workloads on top of "blank" images. For
instance, a CLI/API call such as `aiattach build:<BLANKIMG>:
nullworkload` will result in the Orchestrator attempting to execute
the automated installer with the correct paramaters (i.e., `--role
workload --wks nullworkload`) before proceeding to the regular
Application Instance deployment sequence (i.e., generic scripts,
application-specific scripts and load manager startup).