### PR TITLE
Bandaid for asynchronous attachment

### DIFF
--- a/clients/async_attach_application.py
+++ b/clients/async_attach_application.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+#/*******************************************************************************
+# Copyright (c) 2012 IBM Corp.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/*******************************************************************************
+'''
+Mockup of what needs to happen for CloudNet use case
+'''
+
+#--------------------------------- START CB API --------------------------------
+
+from sys import path, argv
+from time import sleep
+
+import fnmatch
+import os
+import pwd
+
+home = os.environ["HOME"]
+username = pwd.getpwuid(os.getuid())[0]
+
+api_file_name = "/tmp/cb_api_" + username
+if os.access(api_file_name, os.F_OK) :    
+    try :
+        _fd = open(api_file_name, 'r')
+        _api_conn_info = _fd.read()
+        _fd.close()
+    except :
+        _msg = "Unable to open file containing API connection information "
+        _msg += "(" + api_file_name + ")."
+        print _msg
+        exit(4)
+else :
+    _msg = "Unable to locate file containing API connection information "
+    _msg += "(" + api_file_name + ")."
+    print _msg
+    exit(4)
+
+_path_set = False
+
+for _path, _dirs, _files in os.walk(os.path.abspath(path[0] + "/../")):
+    for _filename in fnmatch.filter(_files, "code_instrumentation.py") :
+        if _path.count("/lib/auxiliary") :
+            path.append(_path.replace("/lib/auxiliary",''))
+            _path_set = True
+            break
+    if _path_set :
+        break
+
+from lib.api.api_service_client import *
+
+_msg = "Connecting to API daemon (" + _api_conn_info + ")..."
+print _msg
+api = APIClient(_api_conn_info)
+
+#---------------------------------- END CB API ---------------------------------
+
+if len(argv) < 2 :
+        print "./" + argv[0] + " <cloud_name>"
+        exit(1)
+
+cloud_name = argv[1]
+
+start = int(time())
+expid = "singleai_" + makeTimestamp(start).replace(" ", "_")
+
+print "starting experiment: " + expid
+
+try :
+    app = None
+    error = False
+
+    api.cldalter(cloud_name, "time", "experiment_id", expid)
+
+    _tmp_app = api.appattach(cloud_name, "fio", "default", "default", "none", "none", "none", "empty=empty", "async")
+    print str(_tmp_app)
+    uuid = _tmp_app["uuid"]
+
+    print "Started an App with uuid = " + uuid 
+    while True :
+        sleep(10)
+        applist = api.applist(cloud_name, "pending")
+        pending = False
+        for appitem in applist :
+            if appitem["uuid"] == uuid :
+                pending = True
+                break
+        if not pending :
+            print "Attach complete."
+            app = api.appshow(cloud_name, uuid)
+            break
+        else :
+            print "UUID " + uuid + " is still attaching..."
+
+except APIException, obj :
+    error = True
+    print "API Problem (" + str(obj.status) + "): " + obj.msg
+except KeyboardInterrupt :
+    print "Aborting this experiment."
+except Exception, msg :
+    error = True
+    print "Problem during experiment: " + str(msg)
+
+finally :
+    try :
+        if app :
+            print "Destroying App.."
+            api.appdetach(cloud_name, app["uuid"])
+    except APIException, obj :
+        print "Error cleaning up: (" + str(obj.status) + "): " + obj.msg

--- a/clients/list_vms.go
+++ b/clients/list_vms.go
@@ -28,14 +28,15 @@ import (
 
 func main() {
 	api := api_service_client.APIClient{Address: "http://localhost:7070"}
-	r, err := api.Call("vmlist", "MYSIMCLOUD")
+	name := "MYSIMCLOUD"
+	r, err := api.Call("vmlist", name)
 
 	if err == nil && r["result"] != nil {
 		vms := r["result"].([]interface{})
 		for idx := range vms {
 			vm := vms[idx].(map[string]interface{})
 
-			iter, err := api.Get_latest_management_data("MYSIMCLOUD", vm["uuid"].(string), vm["experiment_id"].(string))
+			iter, err := api.Get_latest_management_data(name, vm["uuid"].(string), vm["experiment_id"].(string))
 			if err != nil {
 				fmt.Printf("ERROR! %s\n", err)
 			}

--- a/lib/api/api_service.py
+++ b/lib/api/api_service.py
@@ -22,6 +22,7 @@
 '''
 from lib.auxiliary.code_instrumentation import trace, cblog, cbdebug, cberr, cbwarn, cbinfo, cbcrit
 from lib.auxiliary.config import parse_cld_defs_file, get_available_clouds
+from time import sleep
 
 from DocXMLRPCServer import DocXMLRPCServer
 import sys
@@ -468,9 +469,14 @@ class API():
             async=async.replace('=','')            
 
             if str(async.split(':')[0]).isdigit() :
-                return self.active.background_execute(parameters + (" async=" + str(async)), "ai-attach")[2]
+                _res = self.active.background_execute(parameters + (" async=" + str(async)), "ai-attach")[2]
             else :
-                return self.active.background_execute(parameters + (" async"), "ai-attach")[2]
+                _res = self.active.background_execute(parameters + (" async"), "ai-attach")[2]
+            # This is hacky, but in order for an asynchronous attach to appear, introduce a delay between when the attach starts
+            # and when a user can safely issue `applist pending`, in order for the pending object to actually show up.
+            # We need a better fix for this later to ensure that the pending object is registered before the API command returns.
+            sleep(10)
+            return _res
         else :
             return self.active.objattach({}, parameters, "ai-attach")[2]
     


### PR DESCRIPTION
1. Our old pub/sub based attach (appinit) doesn't work so well right now,
   so here's a hacky way to perform an asynchronous attach without it.

   It depends on another hack (in the API), which I'm not proud of,
   but it doesn't stop parallelism. It just makes individual requests a little
   slower, even though they still happen in parallel.

   We add a delay in the API for "ailist" to look for pending objects, but
   unfortunately, the API needs some cleanup. There's a period of time (Seconds)
   where between API requests (Detected at scale) where the API can return
   "no" objects at all.

   The only way to fix this temporarily is to add a delay....

   The permanent way to fix this would be to ensure that the appropriate amount
   of locking is introduced between ailist calls in such a way that when a pending
   object moves to "normal" (or "attached") state, that successive calls to the API
   see the right information.

2. The other client is just an example golang client app.