### PR TITLE
Better rsyslog protocol handling

### DIFF
--- a/cbact
+++ b/cbact
@@ -239,7 +239,7 @@ def setup_syslog(operation, facility, verbosity, port, hostname, quiet, logdest,
             hdlr = SysLogHandler(address = (hostname, \
                                             int(port)), \
                                             facility=_syslog_selector[str(_facility)], \
-                                           socktype = socket.SOCK_STREAM if protocol == "TCP" else socket.SOCK_DGRAM)
+                                            socktype = socket.SOCK_STREAM if protocol == "TCP" else socket.SOCK_DGRAM)
 
         # Need to make this rfc3164-compliant by including the 'hostname' and the 'program name'
         formatter = Formatter(socket.getfqdn() + " cloudbench [%(levelname)s] %(message)s")
@@ -404,22 +404,30 @@ def main(options) :
 
         _msci = MongodbMgdConn(str2dic(options.msp)) if options.msp else None
 
-        
         if options.cn :
-            _log_defaults = _osci.get_object(options.cn, "GLOBAL", False, "logstore", False)
             _dir_defaults = _osci.get_object(options.cn, "GLOBAL", False, "space", False)
             if _msci is None :
                 _metricstore = _osci.get_object(options.cn, "GLOBAL", False, "metricstore", False)
-                _msci = MongodbMgdConn(_metricstore) 
+                _msci = MongodbMgdConn(_metricstore)
             _base_dir = _dir_defaults["base_dir"]
-        else :  
+
+	'''
+	 For some historical reason, we're pulling logging options from both Redis and the CLI
+	 This is OK for instances of the actuator that run on the orchestrator machine
+         itself, but for the load manager, it breaks when it runs over the VPN.
+         The modification here is that if and only if we're running as the load manager
+         then use the CLI values instead of the Redis values for logging.
+	'''
+        if _operation.count("execute") or not options.cn :
             _log_defaults = {
-			     "hostname" : options.syslogh,
-			     "port" : options.syslogp,
-			     _operation + "_facility" : options.syslogf,
+                             "hostname" : options.syslogh,
+                             "port" : options.syslogp,
+                             _operation + "_facility" : options.syslogf,
                              "verbosity" : options.verbosity,
                              "protocol" : options.syslogr
-			     }
+                             }
+        else :
+            _log_defaults = _osci.get_object(options.cn, "GLOBAL", False, "logstore", False)  
 
         if str(options.verbosity).strip() != "-1" :
             _log_defaults["verbosity"] = options.verbosity 
@@ -429,9 +437,10 @@ def main(options) :
 			_log_defaults["verbosity"], \
 			_log_defaults["port"], \
 			_log_defaults["hostname"], \
-			options.quiet,
-			options.logdest,
-            _log_defaults["protocol"])
+			options.quiet, \
+			options.logdest, \
+                        _log_defaults["protocol"]
+                        )
 
         if options.oop :
             _parameters = options.oop.split(',')


### PR DESCRIPTION
We had two issues:

1. We enabled TCP support, but had an initialization bug.
2. We also had an issue where the syslog parameters were not
   being pulled by the load manager from the same place,
   but we came up with a workaround for that.