### PR TITLE
Bugs in the libcloud adapter

### DIFF
--- a/configs/cloud_definitions.txt
+++ b/configs/cloud_definitions.txt
@@ -99,7 +99,7 @@ GCE_LOGIN = cbuser                                         # The username that l
 # DigitalOcean (DO) requires the following parameters
 [USER-DEFINED : CLOUDOPTION_MYDIGITALOCEAN]
 DO_INITIAL_VMCS = tor1:sut                                                                       # VMC == DO data center (we don't have availability zones yet)
-DO_CREDENTIALS = long_hex_token_from_digitalocean.com:arbitrarytag1,another_token:arbitrarytag2  # This is your DO access token. The driver supports multiple accounts and will distribute AIs across all accounts in a round-robin fashion.
+DO_CREDENTIALS = long_hex_token_from_digitalocean.com:arbitrarytag1;another_token:arbitrarytag2  # This is your DO access token. The driver supports multiple accounts and will distribute AIs across all accounts in a round-robin fashion.
 DO_SSH_KEY_NAME = cbtool_rsa                                                                     # Either upload credentials/cbtool_rsa.pub to DO or tell us where your private key is
 DO_KEY_NAME = key_name_from_digitialocean.com                                                    # Comma-separated list of IDs (or names) of your DO ssh keys
 DO_LOGIN = root                                                                                  # The username that logins on the VMs

--- a/lib/clouds/do_cloud_ops.py
+++ b/lib/clouds/do_cloud_ops.py
@@ -24,7 +24,6 @@ from libcloud_common import LibcloudCmds
 
 from shared_functions import CldOpsException
 
-
 class DoCmds(LibcloudCmds) :
     @trace
     def __init__ (self, pid, osci, expid = None) :
@@ -34,7 +33,6 @@ class DoCmds(LibcloudCmds) :
                               use_ssh_keys = True, \
                               use_volumes = True, \
                               tldomain = "digitalocean.com", \
-                              extra = {} \
                              )
     # All clouds based on libcloud should define this function.
     # It performs the initial libcloud setup.
@@ -50,12 +48,12 @@ class DoCmds(LibcloudCmds) :
 
     @trace
     def is_cloud_image_uuid(self, imageid) :
-        '''
-        TBD
-        '''
-        if len(imageid) == 8 and is_number(imageid) :
-            return True
+        # DigitalOcean image IDs are just integers, and can be of
+        # arbitrary length. At best we can detect whether or not they
+        # are integers, but the number of digits is never a guarantee.
 
+        if is_number(imageid) :
+            return True
         return False
 
     @trace            
@@ -67,7 +65,7 @@ class DoCmds(LibcloudCmds) :
         return True
     
     @trace
-    def pre_vmcreate_process(self, obj_attr_list, extra, keys) :
+    def pre_vmcreate_process(self, obj_attr_list, keys) :
         '''
         TBD
         '''
@@ -79,17 +77,13 @@ class DoCmds(LibcloudCmds) :
                 obj_attr_list["libcloud_location_inst"] = _location
                 break
 
-        extra["ssh_keys"] = keys
-        
         if obj_attr_list["netname"] == "private" :
-            extra["private_networking"] = True
+            self.vmcreate_kwargs["ex_create_attr"]["private_networking"] = True
 
         obj_attr_list["libcloud_call_type"] = "create_node_with_mixed_arguments"
 
-        self.vmcreate_kwargs["ex_create_attr"] = extra        
+        self.vmcreate_kwargs["ex_create_attr"]["ssh_keys"] = keys
         self.vmcreate_kwargs["ex_user_data"] = obj_attr_list["userdata"]
-
-        return extra
 
     @trace
     def get_description(self) :

--- a/lib/clouds/os_cloud_ops.py
+++ b/lib/clouds/os_cloud_ops.py
@@ -192,7 +192,7 @@ class OsCmds(LibcloudCmds) :
         return True
     
     @trace
-    def pre_vmcreate_process(self, obj_attr_list, extra, keys) :
+    def pre_vmcreate_process(self, obj_attr_list, keys) :
         '''
         TBD
         '''
@@ -244,8 +244,6 @@ class OsCmds(LibcloudCmds) :
         if "cloud_floating_ip" in obj_attr_list :            
             self.vmcreate_kwargs["ex_metadata"]["cloud_floating_ip"] = obj_attr_list["cloud_floating_ip"]
                 
-        return extra
-
     @trace
     def get_description(self) :
         '''

--- a/lib/clouds/vcd_cloud_ops.py
+++ b/lib/clouds/vcd_cloud_ops.py
@@ -29,7 +29,6 @@ class VcdCmds(LibcloudCmds) :
                               use_sizes = False, \
                               use_locations = False, \
                               verify_ssl = False, \
-                              extra = {"foo" : "bar"} \
                              )
 
     # num_credentials = 1: '1' is for the password. The username is assumed to be the first parameter and is included by default as 'tenant' below.
@@ -48,10 +47,11 @@ class VcdCmds(LibcloudCmds) :
         return "VMware VCloud"
 
     @trace
-    def pre_vmcreate(self, obj_attr_list, extra) :
-        extra["kwargs"]["ex_force_customization"] = False
-        extra["kwargs"]["ex_clone_timeout"] = int(obj_attr_list["clone_timeout"])
-        extra["kwargs"]["ex_vm_names"] = ["vm" + obj_attr_list["name"].split("_")[1]]
+    def pre_vmcreate_process(self, obj_attr_list, keys) :
+        self.vmcreate_kwargs["ex_create_attr"] = {}
+        self.vmcreate_kwargs["ex_force_customization"] = False
+        self.vmcreate_kwargs["ex_clone_timeout"] = int(obj_attr_list["clone_timeout"])
+        self.vmcreate_kwargs["ex_vm_names"] = ["vm" + obj_attr_list["name"].split("_")[1]]
 
         _image_id_name = "https://" + obj_attr_list["access"] + "/api/vAppTemplate/vappTemplate-" + obj_attr_list["imageid1"]
         # The common code has already done a search against all image names.
@@ -88,10 +88,9 @@ class VcdCmds(LibcloudCmds) :
 
                 if image is not None :
                     obj_attr_list["image"] = image
-                    extra["kwargs"]["ex_force_customization"] = True 
+                    self.vmcreate_kwargs["ex_force_customization"] = True
                     _msg = "Found an instantiated vApp named "
                     _msg += obj_attr_list["imageid1"]
                     _msg += " Will attempt to clone this vApp."
                     cbdebug (_msg, True)
 
-        return extra


### PR DESCRIPTION
There were a number of errors that needed remedy:

1. Multi-tenancy's use of the comma ',' conflicted with keyword detection at the end of an 'aiattach' command.
   One must now use a semicolon instead of a comma to separate tenant authentication in your config file.

2. The 'vmcreate_kwargs' dictionary must be reset on every invocation.
   It holds values that are specific to each VM create, such as ssh keys and user data and cannot be
   carried between invocations.

3. Vcloud was "probably" broken, although I have no real way to test it.

4. Use of private SSH keys was still broken, when one wants to use keys that are already pre-existing in one's account.

5. Libcloud-based adapters were still causing Redis tagging conflicts because public clouds have no "real" central API ip address.

6. Multi-tenant use of the adapter was also broken because SSH-keys were not being popualted on a per-tenant basis.

7. DigitalOcean's "uuid" image detection was broken, because image IDs are not gauranteed to be 8 characters long.