### PR TITLE
Fix: the FIO workload needs time_based

### DIFF
--- a/scripts/fio/cb.fiojob.template
+++ b/scripts/fio/cb.fiojob.template
@@ -5,6 +5,7 @@ size=FIO_FILE_SIZE
 filename=FIO_FILENAME
 runtime=FIO_RUNTIME
 create_on_open=1
+time_based
 
 [JOB]
 name=fiofile


### PR DESCRIPTION
The fio profile is configured to be time based, but without the
time_based option in the profile, it can exit before the expected
runtime (when it has completely read/written the target file).

Signed-off-by: Julien Desfossez <jdesfossez@digitalocean.com>