### PR TITLE
Fix ROLE_DATA_DIR permission when it's a plain old directory

### DIFF
--- a/scripts/common/cb_common.sh
+++ b/scripts/common/cb_common.sh
@@ -1661,6 +1661,7 @@ function automount_data_dirs {
     then
         syslog_netcat "Creating directory \"$ROLE_DATA_DIR\""
         sudo mkdir -p $ROLE_DATA_DIR
+        sudo chown -R ${my_login_username}:${my_login_username} $ROLE_DATA_DIR
     fi
             
     if [[ $ROLE_DATA_FSTYP == "ramdisk" || $ROLE_DATA_FSTYP == "tmpfs" ]]


### PR DESCRIPTION
A recent commit added variables like HADOOPSLAVE_DATA_DIR and
HADOOPMASTER_DATA_DIR to virtual_application.txt of hadoop workload,
and they have the same value as DFS_DATA_DIR [1]. This breaks hadoop
workload because with that change the directory is created by
automount_data_dirs() and has root as its owner. Since hadoop datanode
service runs as cbuser, it can't write to that directory and fails to
start. The change fixes the issue.

[1] commit 3fa27ac53d5f0682e8d91c9f7e632996e1e29922