### PR TITLE
Parallel Multi-Application Regression test

### DIFF
--- a/regression/real_multicloud_regression.py
+++ b/regression/real_multicloud_regression.py
@@ -220,7 +220,7 @@ def check_vm_attach(apiconn, cloud_model, cloud_name, test_case, options) :
         _model_to_imguuid["plm"] = "xenial"        
         _model_to_imguuid["ec2"] = "ami-a9d276c9"
         _model_to_imguuid["gce"] = "ubuntu-1604-xenial-v20161221"
-        _model_to_imguuid["do"] = "21669205"        
+        _model_to_imguuid["do"] = "cloudbench-nullworkload-on-1604.051818-1"        
         _model_to_imguuid["slr"] = "1836627"        
         _model_to_imguuid["kub"] = "ibmcb/cbtoolbt-ubuntu"
         _model_to_imguuid["as"] = "b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-16_04-LTS-amd64-server-20180112-en-us-30GB"
@@ -892,7 +892,7 @@ def main() :
         _results_row[0] = _results_row[0].center(22, ' ')
 
         if _results_row[1] == "NA" :
-            _results_row[1] = _results_row[1].center(52,' ')
+            _results_row[1] = _results_row[1].center(51,' ')
 
         if _results_row[2] == "NA" :
             _results_row[2] = _results_row[2].center(51,' ')

--- a/regression/real_multicloud_regression_parallel.sh
+++ b/regression/real_multicloud_regression_parallel.sh
@@ -103,23 +103,23 @@ do
     adapter=$(echo $adapter | sed 's/osl/os/g')
     actual_adapter=$(echo $adapter | cut -d ',' -f 1)
     
-	sudo tmux kill-session -t cb${actual_user} > /dev/null 2>&1
-	sudo rm /tmp/${actual_adapter}_real_multicloud_regression_test.txt > /dev/null 2>&1
-	sudo rm /tmp/${actual_adapter}_real_cloud_regression_ecode.txt    > /dev/null 2>&1
-	sudo tmux new -d -s cb${actual_user}
-	sudo tmux send-keys -t cb${actual_user} "sudo chown -R cb${actual_user}:cb${actual_user} /home/cb${actual_user}" Enter	
-	sudo tmux send-keys -t cb${actual_user} "su - cb${actual_user}" Enter
-	sudo tmux send-keys -t cb${actual_user} "cd ~/$CB_ACTUAL_DIR" Enter
-	sudo tmux send-keys -t cb${actual_user} "~/cbsync.sh" Enter
-	sudo tmux send-keys -t cb${actual_user} "time ./regression/real_multicloud_regression.py configs/softlayer_ris ${adapter} ${CB_TEST_LEVEL} private noheader" Enter
-	
+    sudo tmux kill-session -t cb${actual_user} > /dev/null 2>&1
+    sudo rm /tmp/${actual_adapter}_real_multicloud_regression_test.txt > /dev/null 2>&1
+    sudo rm /tmp/${actual_adapter}_real_cloud_regression_ecode.txt    > /dev/null 2>&1
+    sudo tmux new -d -s cb${actual_user}
+    sudo tmux send-keys -t cb${actual_user} "sudo chown -R cb${actual_user}:cb${actual_user} /home/cb${actual_user}" Enter    
+    sudo tmux send-keys -t cb${actual_user} "su - cb${actual_user}" Enter
+    sudo tmux send-keys -t cb${actual_user} "cd ~/$CB_ACTUAL_DIR" Enter
+    sudo tmux send-keys -t cb${actual_user} "~/cbsync.sh" Enter
+    sudo tmux send-keys -t cb${actual_user} "time ./regression/real_multicloud_regression.py configs/softlayer_ris ${adapter} ${CB_TEST_LEVEL} private noheader" Enter
+    
     alist=$adapter' '$alist
 done
 
 alist=$(echo $alist | sed 's/,/ /g' | sed -e $'s/ /\\\n/g' | sort | sed ':a;N;$!ba;s/\n/ /g')
 acount=$(echo $alist | wc -w)
 ecodes=$(sudo ls /tmp/*_real_multicloud_regression_ecode.txt 2>&1 | grep -v 'cannot access' | wc -l)
-
+    
 echo "Will wait until $acount tests ($alist) are completed"
 while [[ "$ecodes" -lt "$acount" ]]
 do
@@ -130,8 +130,8 @@ do
     sudo ls /tmp/*_real_multicloud_regression_test.txt > /dev/null 2>&1
     if [[ $? -eq 0 ]]
     then
-	sudo cat /tmp/a0_real_multicloud_regression_test.txt        
-    for fn in $(ls /tmp/*_real_multicloud_regression_test.txt | grep -v a0_)
+        sudo cat /tmp/a0_real_multicloud_regression_test.txt        
+        for fn in $(ls /tmp/*_real_multicloud_regression_test.txt | grep -v a0_)
         do 
             cat $fn | tail -1
         done


### PR DESCRIPTION
Using a mechanism similar to what is already in place for "Multi-Cloud Regression 
Test" (in paralell), the improvements present here allow one
to test regression on real applications (for instance, using the "Pure
Docker" cloud adapter) in parallel. With this improvement, I was able to
test 32 workloads (some workloads are tested more than once, due to the
need to test with and without Load Balancers) in less than 90 minutes (a
sequential 32-case test was taking roughly 145 minutes to complete).