### PR TITLE
Fix a few bugs with gmetad startup code

### DIFF
--- a/lib/operations/active_operations.py
+++ b/lib/operations/active_operations.py
@@ -1905,6 +1905,12 @@ class ActiveObjectOperations(BaseObjectOperations) :
                     if _obj_type == "VMC" :
                         _status, _fmsg = _cld_conn.vmcregister(obj_attr_list)
                         _vmcregister = True
+
+                        _proc_man = ProcessManagement(username = obj_attr_list["username"], cloud_name = obj_attr_list["cloud_name"])
+                        _gmetad_pid = _proc_man.get_pid_from_cmdline("gmetad.py")
+                        if len(_gmetad_pid) :
+                            cbdebug("Killing the running Host OS performance monitor (gmetad.py)......", True)
+                            _proc_man.kill_process("gmetad.py")
     
                     elif _obj_type == "VM" :
                         self.osci.pending_object_set(_cloud_name, _obj_type, \
@@ -3056,6 +3062,12 @@ class ActiveObjectOperations(BaseObjectOperations) :
                 if _obj_type == "VMC" :
                     self.pre_detach_vmc(obj_attr_list)
                     _status, _msg = _cld_conn.vmcunregister(obj_attr_list)
+
+                    _proc_man = ProcessManagement(username = obj_attr_list["username"], cloud_name = obj_attr_list["cloud_name"])
+                    _gmetad_pid = _proc_man.get_pid_from_cmdline("gmetad.py")
+                    if len(_gmetad_pid) :
+                        cbdebug("Killing the running Host OS performance monitor (gmetad.py)......", True)
+                        _proc_man.kill_process("gmetad.py")
 
                 elif _obj_type == "VM" :
                     self.pre_detach_vm(obj_attr_list)

--- a/lib/remote/process_management.py
+++ b/lib/remote/process_management.py
@@ -34,6 +34,9 @@ class ProcessManagement :
     '''
     TBD
     '''
+
+    allocated_ports = []
+
     @trace
     def __init__(self, hostname = "127.0.0.1", port = "22", username = None, \
                  cloud_name = None, priv_key = None, config_file = None, \
@@ -452,9 +455,10 @@ class ProcessManagement :
         '''
         _port = int(starting_port)
         _pid, _username = self.get_pid_from_port(_port, protocol)
-        while _pid :
+        while _pid or _port in ProcessManagement.allocated_ports :
             _port += 1
             _pid, _username = self.get_pid_from_port(_port, protocol)
+        ProcessManagement.allocated_ports.append(_port)
         return str(_port)
 
     @trace
@@ -532,12 +536,12 @@ class ProcessManagement :
             # Same comment
             sleep(3)
 
-        _pid = self.get_pid_from_cmdline(cmdline if not search_keywords else search_keywords)
+        _pidlist = self.get_pid_from_cmdline(cmdline if not search_keywords else search_keywords)
 
         _msg = "A process with the command line \"" + cmdline + "\" (pid "
-        _msg += str(_pid) + ") was started succesfully."
+        _msg += str(_pidlist) + ") was started succesfully."
         cbdebug(_msg)
-        return [ _pid ]
+        return _pidlist
 
     @trace
     def kill_process(self, cmdline, kill_options = False, port = False) :


### PR DESCRIPTION
After enabling COLLECT_FROM_HOST, I observed the issue consistenly if I
exited cbtool without detaching VMC or cloud and restarted it with --soft_reset
option:

  status: Host OS performance monitor daemon (gmetad.py) started successfully.
          The process id is [] (using ports 8653 and 8653).

This occurs due to a few bugs with gmetad startup code:

- One is with ProcessManagement.start_daemon(). Note that get_pid_from_cmdline()
  returns an empty list when it fails to find matching process. In that case,
  start_daemon() returns a list containing one empty list. The value is not
  considered empty in Python and makes cbtool mistakenly thinks the process
  was started successfully although it wasn't.

- Another is with ProcessManagement.get_free_port(). It allocates the same
  port when being called multiple times.

The change fixes the above bugs. It also kills gmetad left in prior session
when cbtool re-attaches to VMC.