### PR TITLE
Revert "Fix a few bugs with gmetad startup code"

### DIFF
--- a/lib/operations/active_operations.py
+++ b/lib/operations/active_operations.py
@@ -1905,12 +1905,6 @@ class ActiveObjectOperations(BaseObjectOperations) :
                     if _obj_type == "VMC" :
                         _status, _fmsg = _cld_conn.vmcregister(obj_attr_list)
                         _vmcregister = True
-
-                        _proc_man = ProcessManagement(username = obj_attr_list["username"], cloud_name = obj_attr_list["cloud_name"])
-                        _gmetad_pid = _proc_man.get_pid_from_cmdline("gmetad.py")
-                        if len(_gmetad_pid) :
-                            cbdebug("Killing the running Host OS performance monitor (gmetad.py)......", True)
-                            _proc_man.kill_process("gmetad.py")
     
                     elif _obj_type == "VM" :
                         self.osci.pending_object_set(_cloud_name, _obj_type, \
@@ -3062,12 +3056,6 @@ class ActiveObjectOperations(BaseObjectOperations) :
                 if _obj_type == "VMC" :
                     self.pre_detach_vmc(obj_attr_list)
                     _status, _msg = _cld_conn.vmcunregister(obj_attr_list)
-
-                    _proc_man = ProcessManagement(username = obj_attr_list["username"], cloud_name = obj_attr_list["cloud_name"])
-                    _gmetad_pid = _proc_man.get_pid_from_cmdline("gmetad.py")
-                    if len(_gmetad_pid) :
-                        cbdebug("Killing the running Host OS performance monitor (gmetad.py)......", True)
-                        _proc_man.kill_process("gmetad.py")
 
                 elif _obj_type == "VM" :
                     self.pre_detach_vm(obj_attr_list)

--- a/lib/remote/process_management.py
+++ b/lib/remote/process_management.py
@@ -34,9 +34,6 @@ class ProcessManagement :
     '''
     TBD
     '''
-
-    allocated_ports = []
-
     @trace
     def __init__(self, hostname = "127.0.0.1", port = "22", username = None, \
                  cloud_name = None, priv_key = None, config_file = None, \
@@ -455,10 +452,9 @@ class ProcessManagement :
         '''
         _port = int(starting_port)
         _pid, _username = self.get_pid_from_port(_port, protocol)
-        while _pid or _port in ProcessManagement.allocated_ports :
+        while _pid :
             _port += 1
             _pid, _username = self.get_pid_from_port(_port, protocol)
-        ProcessManagement.allocated_ports.append(_port)
         return str(_port)
 
     @trace
@@ -536,12 +532,12 @@ class ProcessManagement :
             # Same comment
             sleep(3)
 
-        _pidlist = self.get_pid_from_cmdline(cmdline if not search_keywords else search_keywords)
+        _pid = self.get_pid_from_cmdline(cmdline if not search_keywords else search_keywords)
 
         _msg = "A process with the command line \"" + cmdline + "\" (pid "
-        _msg += str(_pidlist) + ") was started succesfully."
+        _msg += str(_pid) + ") was started succesfully."
         cbdebug(_msg)
-        return _pidlist
+        return [ _pid ]
 
     @trace
     def kill_process(self, cmdline, kill_options = False, port = False) :


### PR DESCRIPTION
Reverts ibmcb/cbtool#223

@rayx Greetings, my friend. This commit is causing an issue during initial startup of cbtool. What happens is something like this:

```
mariner@mariner-amazon-us-east-1:~/cbtool$ pkill -9 -f redis
mariner@mariner-amazon-us-east-1:~/cbtool$ ./cb -f 
Cbtool version is "8c5fe37"
Parsing "cloud definitions" file..... "/home/mariner/cbtool/lib/auxiliary//../..//configs/mariner_cloud_definitions.txt" opened and parsed successfully.

Checking "Object Store"..... Unable to detect a private Redis server daemon running. Please try to start one (e.g., redis-server /home/mariner/cbtool/lib/auxiliary//../../stores/mariner_redis.conf)
Parsing "cloud definitions" file.....
```

This is very reproducible. So, for the short term, I'm going to revert this. Can you take a look and see what's going on?

What happens above is that the Redis server does in fact get started, but the PR you submitted somehow makes cbtool think that it is dead.

Thank you so much for the contributions, by the way! These PRs have been great........ just a minor bump in the road. :)