### PR TITLE
rsyslog: Unbreak TCP linebreaks

### DIFF
--- a/cbact
+++ b/cbact
@@ -44,6 +44,39 @@ from lib.stores.redis_datastore_adapter import RedisMgdConn
 
 from daemon import DaemonContext
 
+# Extend the class so that we emit a newline instead of the #000 character
+# when running over TCP
+# This bug was fixed in python v3, but not v2: https://bugs.python.org/issue12168
+class NewlineSysLogHandler(logging.handlers.SysLogHandler):
+    def emit(self, record):
+        try:
+            msg = self.format(record) + '\n'
+            """
+            We need to convert record level to lowercase, maybe this will
+            change in the future.
+            """
+            prio = '<%d>' % self.encodePriority(self.facility,
+                                                self.mapPriority(record.levelname))
+            # Message is a string. Convert to bytes as required by RFC 5424
+            if type(msg) is unicode:
+                msg = msg.encode('utf-8')
+            msg = prio + msg
+            if self.unixsocket:
+                try:
+                    self.socket.send(msg)
+                except socket.error:
+                    self.socket.close() # See issue 17981
+                    self._connect_unixsocket(self.address)
+                    self.socket.send(msg)
+            elif self.socktype == socket.SOCK_DGRAM:
+                self.socket.sendto(msg, self.address)
+            else:
+                self.socket.sendall(msg)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except:
+            self.handleError(record)
+
 def actuator_cli_parsing() :
     
     # Do command line parsing
@@ -236,10 +269,14 @@ def setup_syslog(operation, facility, verbosity, port, hostname, quiet, logdest,
             if _facility > 23 or _facility < 16 :
                 _facility = 23
 
-            hdlr = SysLogHandler(address = (hostname, \
-                                            int(port)), \
-                                            facility=_syslog_selector[str(_facility)], \
-                                            socktype = socket.SOCK_STREAM if protocol == "TCP" else socket.SOCK_DGRAM)
+            if protocol == "TCP" :
+                hdlr = NewlineSysLogHandler(address = (hostname, int(port)),
+                                            facility=_syslog_selector[str(_facility)],
+                                            socktype = socket.SOCK_STREAM)
+            else :
+                hdlr = SysLogHandler(address = (hostname, int(port)),
+                                            facility=_syslog_selector[str(_facility)],
+                                            socktype = socket.SOCK_DGRAM)
 
         # Need to make this rfc3164-compliant by including the 'hostname' and the 'program name'
         formatter = Formatter(socket.getfqdn() + " cloudbench [%(levelname)s] %(message)s")

--- a/lib/auxiliary/cli.py
+++ b/lib/auxiliary/cli.py
@@ -536,7 +536,8 @@ class CBCLI(Cmd) :
             hdlr = StreamHandler(stdout)
         elif options.logdest == "syslog" :
             hdlr = SysLogHandler(address = (options.syslogn, int(options.syslogp)), \
-                                 facility=_syslog_selector[str(options.syslogf)])
+                                 facility=_syslog_selector[str(options.syslogf)],
+                                 socktype = socket.SOCK_DGRAM)
         else :
             hdlr = RotatingFileHandler(options.logdest, maxBytes=20971520, \
                                        backupCount=20)


### PR DESCRIPTION
At scale, TCP logging at scale performs much better than UDP when sending
logs over the internet.

TCP logs from any `cbact` processes were getting lost due to line
breaks because of this bug: https://bugs.python.org/issue12168

With this change, if the TCP protocol is chosen, we override
the syslog handler class to fix the line break to use a newline
so that logs are received properly.