### PR TITLE
Fix for the ability of deploying workloads using unconfigured images.

### DIFF
--- a/lib/operations/active_operations.py
+++ b/lib/operations/active_operations.py
@@ -2423,7 +2423,7 @@ class ActiveObjectOperations(BaseObjectOperations) :
                 _cmd = "~/" + obj_attr_list["remote_dir_name"] + "/scripts/common/cb_post_boot.sh"
 
                 _status, _result_stdout, _result_stderr = \
-                        _proc_man.retriable_run_os_command(_cmd, obj_attr_list["uuid"], \
+                        _proc_man.retriable_run_os_command(obj_attr_list["generic_post_boot_command"], obj_attr_list["uuid"], \
                                                            really_execute = obj_attr_list["run_generic_scripts"], \
                                                            debug_cmd = obj_attr_list["debug_remote_commands"], \
                                                            total_attempts = int(obj_attr_list["update_attempts"]),\


### PR DESCRIPTION
 Use the value of the VM attribute "generic_post_boot_command", instead
 of the prefixed "./scripts/common/cb_post_boot.sh". Required for the
 "building workloads on the fly while deploying against unconfigured
 images" functionality.