### PR TITLE
Fix for wrong message in OpenStack clouds

### DIFF
--- a/lib/clouds/osk_cloud_ops.py
+++ b/lib/clouds/osk_cloud_ops.py
@@ -1190,7 +1190,9 @@ class OskCmds(CommonCloudFunctions) :
                 _imageid = None
                 if str(obj_attr_list["boot_from_volume"]).lower() == "true" :
                     _imageid = obj_attr_list["boot_volume_imageid1"]
-                
+                    obj_attr_list["cloud_vv_data_name"] = obj_attr_list["cloud_vv_name"]
+                    obj_attr_list["cloud_vv_name"] = obj_attr_list["cloud_vv_name"].replace("-vv","-vbv")
+
                 obj_attr_list["last_known_state"] = "about to send volume create request"
                 _mark_a = time()
                 if str(self.oskconnstorage[obj_attr_list["name"]].version) == '1' :

--- a/lib/clouds/shared_functions.py
+++ b/lib/clouds/shared_functions.py
@@ -1893,7 +1893,7 @@ packages:"""
     
                 _msg = "Creating volume \"" + obj_attr_list["cloud_vv_name"] + "\""                    
                 _msg += ", type \"" + str(obj_attr_list["cloud_vv_type"]) + "\""
-                if str(obj_attr_list["boot_from_volume"]).lower() == "true" :
+                if str(obj_attr_list["boot_from_volume"]).lower() == "true" and obj_attr_list["cloud_vv_name"].count("-vbv") :
                     _msg += ", from image \"" + obj_attr_list["imageid1"] + "\" (boot_volume)"
                 else :                
                     _msg += ", with size " + str(obj_attr_list["cloud_vv"]) + " GB,"


### PR DESCRIPTION
Fix the wrong message in OpenStack by properly differentiating between data volumes and boot volumes from base images.