### PR TITLE
sysbench: add more tunables

### DIFF
--- a/scripts/sysbench/cb_restart_mysql.sh
+++ b/scripts/sysbench/cb_restart_mysql.sh
@@ -47,7 +47,7 @@ fi
 
 ${SUDO_CMD} sed -i "s^bind-address.*^bind-address            = $my_ip_addr^g" ${MYSQL_CONF_FILE}
 
-# Set mysql's memory cache size to be 70% of main memory
+# Set mysql's memory cache size to be a percentage of main memory
 kb=$(cat /proc/meminfo  | sed -e "s/ \+/ /g" | grep MemTotal | cut -d " " -f 2)
 mb=$(echo "$kb / 1024 * ${MYSQL_RAM_PERCENTAGE} / 100" | bc)
 ${SUDO_CMD} su -c "echo 'innodb_buffer_pool_size = ${mb}M' >> ${MYSQL_CONF_FILE}"

--- a/scripts/sysbench/virtual_application.txt
+++ b/scripts/sysbench/virtual_application.txt
@@ -41,6 +41,10 @@ MYSQL_NONROOT_USER = sysbench
 MYSQL_NONROOT_PASSWORD = sysbench
 TABLE_SIZE = 10000
 READ_ONLY = off
+# Probably ubuntu-specific. May need to override for CentOS
+MYSQL_CONF_FILE = /etc/mysql/mysql.conf.d/mysqld.cnf
+# Default to 70% of main memory
+MYSQL_RAM_PERCENTAGE = 70
 
 # Inter-Virtual Application instances (inter-AI) synchronized execution. Entirely optional
 #SYNC_COUNTER_NAME = synchronization_counter


### PR DESCRIPTION
1. Change the amount of RAM used by mysql on the fly
2. Make the location of the mysql cnf file configurable.