### PR TITLE
Minor updates

### DIFF
--- a/configs/templates/internal_options.txt
+++ b/configs/templates/internal_options.txt
@@ -319,7 +319,8 @@ COLLECTOR_HOST_SUMMARIZER_PORT = 8652
 COLLECTOR_VM_AGGREGATOR_PORT = 8651
 COLLECTOR_VM_SUMMARIZER_PORT = 8652
 FILLER_STRING=NA
-UNCHANGED_STRING=(unchanged)
+#UNCHANGED_STRING=(unchanged)
+UNCHANGED_STRING=None
 
 # Attributes recorded during management operations
 TRACE_ATTRIBUTES = command_originated, command, name, vmc_arrived, 

--- a/lib/auxiliary/gui.py
+++ b/lib/auxiliary/gui.py
@@ -1961,6 +1961,7 @@ class GUIDispatcher(Resource) :
         self.third_party = File(cwd + "/3rd_party")
         self.files = File(cwd + "/gui_files")
         self.fdrs = File(cwd + "/../driver")
+        self.hfdrs = File(cwd + "/../osgcloud/driver")
         self.icon = File(cwd + "/gui_files/favicon.ico")
         self.git = File(cwd + "/.git")
         self.git.indexNames = ["test.rpy"]
@@ -1993,6 +1994,8 @@ class GUIDispatcher(Resource) :
             return self.third_party
         elif name.count("gui_files") :
             return self.files
+        elif name.count("hfdrs") :
+            return self.hfdrs
         elif name.count("fdrs") :
             return self.fdrs
         elif name.count("favicon.ico"):


### PR DESCRIPTION
1. Set the default unchanged string to None
2. Modify the GUI so that file listings (e.g. SPEC FDR reports) are available
   in the UI directly in both ~/cbtool as well as ~/osgcloud/cbtool