### PR TITLE
DO k8s: First working implementation

### DIFF
--- a/configs/templates/_dok8s.txt
+++ b/configs/templates/_dok8s.txt
@@ -1,0 +1,163 @@
+[USER-DEFINED]
+DOK8S_ACCESS = https://api.digitalocean.com/v2 
+# Name of the ssh key pair 
+DOK8S_KEY_NAME = cbtool_rsa
+DOK8S_SSH_KEY_NAME = cbtool_rsa
+DOK8S_LOGIN = need_to_be_configured_by_user
+DOK8S_INITIAL_VMCS = need_to_be_configured_by_user
+DOK8S_NETNAME = need_to_be_configured_by_user
+
+# PEBCAK documentation for the Wizard and CLI
+DOK8S_ACCESS_DOC = Please enter the full path to the kubernetes configuration file
+DOK8S_ACCESS_DEFAULT = tcp://<address>:2375
+DOK8S_LOGIN_DOC = $LOGIN_DOC
+DOK8S_LOGIN_DEFAULT = klabuser
+DOK8S_SSH_KEY_NAME_DOC = $SSH_KEY_NAME_DOC
+DOK8S_SSH_KEY_NAME_DEFAULT = id_rsa.private
+DOK8S_INITIAL_VMCS_DOC = $INITIAL_VMCS_DOC 
+DOK8S_INITIAL_VMCS_DEFAULT = world:sut
+DOK8S_NETNAME_DOC = "Please enter the name of the network that will connect all created Containers"
+DOK8S_NETNAME_DEFAULT = private
+
+[SPACE : DOK8S_CLOUDCONFIG ]
+SSH_KEY_NAME = $DOK8S_SSH_KEY_NAME
+
+[MON_DEFAULTS : DOK8S_CLOUDCONFIG ]
+COLLECT_FROM_HOST = $False
+COLLECT_FROM_GUEST = $False
+
+[VMC_DEFAULTS : DOK8S_CLOUDCONFIG]
+INITIAL_VMCS = $DOK8S_INITIAL_VMCS
+DISCOVER_HOSTS = $False
+ACCESS = $Empty
+CREDENTIALS = $Empty
+SECURITY_GROUPS = $Empty
+KEY_NAME = $DOK8S_KEY_NAME
+ADDITIONAL_DISCOVERY = $Empty
+MIGRATE_SUPPORTED = $False
+PROTECT_SUPPORTED = $False
+HOST_USER_ROOT = $False
+
+[VM_DEFAULTS : DOK8S_CLOUDCONFIG]
+ACCESS = $Empty
+CREDENTIALS = $Empty
+EXTRA_INFO = $Empty
+HOSTS_PER_VMC = 5
+CAPTURE_SUPPORTED = $False
+RUNSTATE_SUPPORTED = $True
+RESIZE_SUPPORTED = $False
+LOGIN = $DOK8S_LOGIN
+SECURITY_GROUPS = $Empty
+KEY_NAME = $DOK8S_KEY_NAME
+SSH_KEY_NAME = $DOK8S_SSH_KEY_NAME
+CHECK_BOOT_STARTED = poll_cloud
+# Other methods could be used to check if a VM *STARTED* booting
+#CHECK_BOOT_STARTED = subscribe_on_starting
+CHECK_BOOT_COMPLETE = tcp_on_22
+# Other methods could be used to check if a VM *FINISHED* booting
+#CHECK_BOOT_COMPLETE = subscribe_on_booting
+#CHECK_BOOT_COMPLETE = wait_for_0
+NETNAME = private
+TENANT = default
+SIZE = from_vm_template
+LEAVE_INSTANCE_ON_FAILURE = $False
+FORCE_FAILURE = $False
+DISABLE_TIMESYNC = $True
+NAMESPACE = default
+ABSTRACTION = pod
+REPLICAS = 1
+PORTS_BASE = 10000
+IMAGE_PREFIX = ibmcb/ubuntu_
+IMAGE_SUFFIX = $EMPTY
+DOCKER_REPO = https://hub.docker.com/r/
+ANNOTATIONS = $Empty
+
+[AI_DEFAULTS : DOK8S_CLOUDCONFIG]
+CAPTURE_SUPPORTED = $False
+RUNSTATE_SUPPORTED = $True
+RESIZE_SUPPORTED = $True
+RUN_APPLICATION_SCRIPTS = $True
+LOGIN = $DOK8S_LOGIN
+SSH_KEY_NAME = $DOK8S_SSH_KEY_NAME
+ATTACH_PARALLELISM = 5
+NAMESPACE = default
+ABSTRACTION = pod
+PORTS_BASE = 10000
+
+[AIDRS_DEFAULTS : DOK8S_CLOUDCONFIG]
+LOGIN = $DOK8S_LOGIN
+SSH_KEY_NAME = $DOK8S_SSH_KEY_NAME
+
+[VMCRS_DEFAULTS : DOK8S_CLOUDCONFIG]
+LOGIN = $DOK8S_LOGIN
+SSH_KEY_NAME = $DOK8S_SSH_KEY_NAME
+
+[FIRS_DEFAULTS : DOK8S_CLOUDCONFIG]
+LOGIN = $DOK8S_LOGIN
+SSH_KEY_NAME = $DOK8S_SSH_KEY_NAME
+
+[VM_TEMPLATES : DOK8S_CLOUDCONFIG]
+ACMEAIR = size:2-4096, imageid1:cb_acmeair
+APACHE = size:2-4096, imageid1:cb_wrk
+BONNIE = size:2-2048, imageid1:cb_bonnie
+BTEST = size:2-2048, imageid1:cb_btest
+CASSANDRA = size:2-4096, eclipsed_size:gold32, imageid1:cb_ycsb
+CHECK = size:1-256, imageid1:to_replace
+CLIENT_IBM_DAYTRADER = size:2-4096, imageid1:cb_daytrader
+CLIENT_OPEN_DAYTRADER = size:2-4096, imageid1:cb_open_daytrader
+CLIENT_TRADELITE = size:2-4096, imageid1:cb_tradelite
+CLIENT_WINDOWS = size:2-4096, imageid1:cb_windows
+CN_HPC = size:2-4096, imageid1:cb_hpcc
+COREMARK = size:1-1024, eclipsed_size:gold32, imageid1:cb_coremark
+DB2 = size:2-4096, lb_size:gold32, eclipsed_size:gold32, imageid1:cb_daytrader
+DDGEN = size:2-2048, imageid1:cb_ddgen
+DRIVER_COREMARK = size:1-1024, imageid1:cb_coremark
+DRIVER_DAYTRADER = size:2-4096, imageid1:cb_daytrader
+DRIVER_FILEBENCH = size:2-4096, imageid1:cb_filebench
+DRIVER_FIO = size:2-4096, imageid1:cb_fio
+DRIVER_HADOOP = size:1-1024, imageid1:cb_hadoop
+DRIVER_NETPERF = size:1-1024, imageid1:cb_netperf
+DRIVER_TRADELITE = size:2-4096, imageid1:cb_tradelite
+FEN_HPC = size:2-4096, imageid1:cb_hpcc
+FILEBENCH = size:1-2048, eclipsed_size:gold32, imageid1:cb_filebench
+FIO = size:2-2048, imageid1:cb_fio
+GERONIMO = size:2-4096, eclipsed_size:gold32, imageid1:cb_open_daytrader
+GIRAPHMASTER = size:1-2048, eclipsed_size:gold32, imageid1:cb_giraph
+GIRAPHSLAVE = size:2-4096, eclipsed_size:gold32, imageid1:cb_giraph
+HADOOPMASTER = size:1-2048, eclipsed_size:gold32, imageid1:cb_hadoop
+HADOOPSLAVE = size:2-4096, eclipsed_size:gold32, imageid1:cb_hadoop
+IPERFCLIENT = size:1-512, imageid1:cb_iperf
+IPERFSERVER = size:1-512, imageid1:cb_iperf
+LB = size:2-4096, eclipsed_size:gold32, imageid1:cb_nullworkload
+LIBERTY = size:2-4096, imageid1:cb_acmeair
+LINPACK = size:2-4096, imageid1:cb_linpack
+MEMTIER = size:2-4096, imageid1:cb_memtier
+MONGO_CFG_SERVER = size:1-2048, imageid1:cb_ycsb
+MONGODB = size:2-4096, eclipsed_size:gold32, imageid1:cb_ycsb
+MONGOS = size:4-8192, eclipsed_size:gold32, imageid1:cb_ycsb
+MULTICHASE = size:2-4096, imageid1:cb_multichase
+MYSQL = size:2-4096, lb_size:gold32, eclipsed_size:gold32, imageid1:cb_open_daytrader
+NETCLIENT = size:2-512, imageid1:cb_netperf
+NETSERVER = size:1-512, imageid1:cb_netperf
+NUTTCPCLIENT = size:1-512, imageid1:cb_nuttcp
+NUTTCPSERVER = size:1-512, imageid1:cb_nuttcp
+OLDISIMDRIVER = size:1-1024, imageid1:cb_oldisim
+OLDISIMLB = size:1-1024, imageid1:cb_oldisim
+OLDISIMLEAF = size:1-1024, imageid1:cb_oldisim
+OLDISIMROOT = size:1-1024, imageid1:cb_oldisim
+PARBOIL = size:2-4096, imageid1:cb_parboil
+POSTMARK = size:2-2048, imageid1:cb_postmark
+REDIS = size:2-4096, imageid1:cb_ycsb
+SCIMARK = size:1-2048, imageid1:cb_scimark
+SEED = size:2-4096, imageid1:cb_ycsb
+SPECJBB = size:2-4096, eclipsed_size:gold32, imageid1:cb_specjbb
+SYSBENCH = size:2-4096, imageid1:cb_sysbench
+TINYVM = size:1-256, imageid1:cb_nullworkload
+UNIXBENCH = size:2-2048, imageid1:cb_unixbench
+WAS = size:2-4096, eclipsed_size:gold32, imageid1:cb_daytrader
+WINDOWS = size:2-4096 imageids:1, imageid1:cb_windows
+WRK = size:1-2048, imageid1:cb_wrk
+XPINGRECEIVER =  size:1-256, imageid1:cb_xping
+XPINGSENDER =  size:1-256, imageid1:cb_xping
+YATINYVM = size:1-256, imageid1:cb_nullworkload
+YCSB = size:2-4096, imageid1:cb_ycsb

--- a/lib/clouds/dok8s_cloud_ops.py
+++ b/lib/clouds/dok8s_cloud_ops.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python
+
+#/*******************************************************************************
+# Copyright (c) 2015 DigitalOcean, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#/*******************************************************************************
+
+'''
+    Created on October 10, 2018
+    DigitalOcean Kubernetes Object Operations Library
+    @author: Michael R. Hines
+'''
+
+import requests
+import yaml
+from requests.adapters import HTTPAdapter
+from json import loads
+from time import sleep, time
+
+from lib.auxiliary.code_instrumentation import trace, cbdebug, cberr, cbwarn, cbinfo, cbcrit
+from shared_functions import CldOpsException
+
+from libcloud_common import LibcloudCmds
+from kub_cloud_ops import KubCmds
+
+import operator
+import pykube
+import traceback
+
+
+class Dok8sCmds(KubCmds) :
+    @trace
+    def __init__ (self, pid, osci, expid = None) :
+        self.kubeconfig = False
+        self.kuuid = False
+        # change to 'access'
+        KubCmds.__init__(self, pid, osci, expid = expid)
+
+    @trace
+    def get_description(self) :
+        return "DigitalOcean Kubernetes Cloud"
+
+    @trace
+    def connect(self, access, credentials, vmc_name, extra_parms = {}, diag = False, generate_rc = False) :
+        try :
+            if not diag and not self.kubeconn :
+                # Move the pykube call into the kub adapter itself so we don't have to import it
+                self.kubeconn = pykube.HTTPClient(pykube.KubeConfig(yaml.safe_load(self.kubeconfig)))
+
+            return KubCmds.connect(self, access, credentials, vmc_name, extra_parms, diag, generate_rc)
+        except Exception, e :
+            for line in traceback.format_exc().splitlines() :
+                cbwarn(line, True)
+            raise e
+
+    @trace
+    def get_session(self) :
+        s = requests.Session()
+        s.mount('http', HTTPAdapter(max_retries=3))
+        s.mount('https', HTTPAdapter(max_retries=3))
+        s.headers.update(self.headers)
+
+        return s
+
+    @trace
+    def create_cluster(self, obj_attr_list) :
+        kuuid = False
+        kubeconfig = False
+
+        try :
+            s = self.get_session()
+
+            kname = "cb-" + obj_attr_list["username"] + '-' + obj_attr_list["cloud_name"].lower() + "-" + obj_attr_list["name"]
+
+            # First make sure there aren't any pre-existing clusters with this name.
+            # If so, destroy them.
+            r = s.get(self.access + "/kubernetes/clusters")
+
+            if r.status_code == 200 :
+                for cluster in r.json()["kubernetes_clusters"] :
+                    if cluster["name"] == kname :
+                        self.destroy_cluster(cluster["uuid"])
+            else :
+                cbdebug("Cluster cleanup failed: " + str(r.status_code), True)
+                raise CldOpsException("Could not cleanup old clusters.", 470)
+
+            create = {
+                "kubernetes_cluster": {
+                    "name": kname,
+                    "region": obj_attr_list["name"],
+                    "version":"1.11.1-do.1",
+                    "worker_pools": [
+                        {
+                            "droplet_size" : "s-2vcpu-4gb",
+                            "version" : "1.11.1-do.1",
+                            "num_nodes" : 2,
+                            "name" : kname + "-pool"
+                        }
+                    ]
+                }
+            }
+
+            # need tolerate errors, obviously
+            r = s.post(self.access + "/kubernetes/clusters", json = create)
+
+            if r.status_code == 201 :
+                j = r.json()
+                kuuid = j["kubernetes_cluster"]["uuid"]
+                cbdebug("Waiting for ready status uuid: " + kuuid)
+            else :
+                cbdebug("Create failed: " + str(r.status_code), True)
+                raise CldOpsException("No k8s for you.", 459)
+
+            while True :
+                r = s.get(self.access + "/kubernetes/clusters/" + kuuid)
+
+                if r.status_code == 200 :
+                    if not r.json()["kubernetes_cluster"]["pending"] :
+                        cbdebug("Done.")
+                        break
+
+                    sleep(5)
+                    continue
+
+            cbdebug("Getting kubeconfig for cluster " + kuuid)
+            r = s.get(self.access + "/kubernetes/clusters/" + kuuid + "/kubeconfig")
+
+            if r.status_code == 200 :
+                kubeconfig = r.text
+                cbdebug("Got kubeconfig")
+            else :
+                cbdebug("Failed to get kubeconfig: " + str(r.status_code))
+                raise CldOpsException("Failed to get kubeconfig: " + str(r.status_code), 460)
+
+            fwname = "k8s-" + kuuid + "-worker"
+            cbdebug("Modifying firewall " + fwname + " for this cluster...")
+
+            if r.status_code == 200 :
+                r = s.get(self.access + "/firewalls")
+            else :
+                cbdebug("Failed to get firewall " + fwname + ": " + str(r.status_code), True)
+                raise CldOpsException("No k8s for you.", 461)
+
+            firewalls = r.json()
+
+            fwuuid = False
+
+            for fw in firewalls["firewalls"] :
+                if fw['name'] == fwname :
+                    fwuuid = fw['id']
+                    cbdebug("Firewall found: " + fwuuid)
+
+            cbdebug("Adding rule to firewall " + fwuuid)
+
+            rule = {
+              "inbound_rules": [
+                {
+                  "protocol": "tcp",
+                  "ports": "40000-45000",
+                  "sources": {
+                        "addresses": [
+                          "0.0.0.0/0",
+                          "::/0"
+                        ]
+                  }
+                }
+              ]
+            }
+
+            r = s.post(self.access + "/firewalls/" + fwuuid + "/rules", json = rule)
+
+            if r.status_code == 204 :
+                cbdebug("Successfully added firewall rule to " + fwuuid)
+            else :
+                cbdebug("Firewall rule add failed: " + str(r.status_code), True)
+        except Exception, e :
+            for line in traceback.format_exc().splitlines() :
+                cbwarn(line, True)
+            cberr("Failure to create k8s cluster: " + str(e), True)
+            return False, False
+
+        return kuuid, kubeconfig
+
+    @trace
+    def destroy_cluster(self, kuuid) :
+        try :
+            s = self.get_session()
+
+            cbdebug("Destroying Cluster: " + kuuid, True)
+
+            r = s.delete(self.access + "/kubernetes/clusters/" + kuuid)
+
+            if r.status_code != 202 :
+                cbdebug("Failed to delete: " + str(r.status_code), True)
+                raise CldOpsException("Destroy cluster failed.", 462)
+                
+            # Check for delete complete....
+
+            cbdebug("Waiting for delete to finish...")
+            while True :
+                r = s.get(self.access + "/kubernetes/clusters/" + kuuid)
+
+                if r.status_code == 404 or (r.status_code == 200 and not r.json()["kubernetes_cluster"]["pending"]) :
+                    cbdebug("Done.")
+                    break
+
+                sleep(5)
+                continue
+                    
+            cbdebug("Deleted " + kuuid)
+            return True
+
+        except Exception, e :
+            for line in traceback.format_exc().splitlines() :
+                cbwarn(line, True)
+            cberr("Failure to destroy k8s cluster: " + str(e), True)
+            return False
+
+    @trace
+    def vmcregister(self, obj_attr_list) :
+        try :
+            if not self.kubeconfig :
+                if "kubeconfig" not in obj_attr_list :
+                    credentials = "63c4a071ae4795dcbdd424ff403856170bdb4c359a7b9278f0158b501f98ef17"
+                    self.access = obj_attr_list["access"]
+                    self.headers = {"Authorization" : "Bearer " + credentials}
+                    # This really should be in vmcregister()
+                    cbdebug("Creating cluster: " + obj_attr_list["name"], True)
+                    obj_attr_list["kuuid"], obj_attr_list["kubeconfig"] = self.create_cluster(obj_attr_list)
+                    if not obj_attr_list["kuuid"] :
+                        raise CldOpsException("vmcregister, No k8s for you.", 458)
+                self.kubeconfig = obj_attr_list["kubeconfig"]
+                self.kuuid = obj_attr_list["kuuid"]
+        except Exception, e :
+            for line in traceback.format_exc().splitlines() :
+                cbwarn(line, True)
+            raise e
+
+        status, msg = KubCmds.vmcregister(self, obj_attr_list)
+        return status, msg
+
+    # Store things into the object. kubeconfig. kuuid, etc.
+    # This should be vmcunregister, not cleanup
+    @trace
+    def vmcunregister(self, obj_attr_list) :
+        status, msg = KubCmds.vmcunregister(self, obj_attr_list)
+        if status == 0 and "kubeconfig" in obj_attr_list :
+            success = self.destroy_cluster(obj_attr_list["kuuid"])
+            if not success :
+                status = 463
+                msg = "Failed to destroy k8s cluster"
+        return status, msg 


### PR DESCRIPTION
This commit does a few things:

1. We inherit from the base class in kub_cloud_ops.py and leave the file pretty much unchanged
2. We then create DigitalOcean clusters on demand. (There is no libcloud support to do this, unfortunately)
3. Then we're able to use all of the existing k8s functions to create containers with very little changes.

It works! It's probably got bugs, but it works.

Because it's k8s, it has a really nice side effect that once the cluster is created, all future commands
go to k8s, so in terms of error handling and things like that, all future code can remain
in the original "kub" adapter without having to extend too much error handling to all of the
other cloud providers.

We should be able to use the file "dok8s_cloud_ops.py" as a pretty good template for the remaining clouds.