### PR TITLE
k8s: additional compatibility

### DIFF
--- a/lib/clouds/kub_cloud_ops.py
+++ b/lib/clouds/kub_cloud_ops.py
@@ -550,7 +550,7 @@ class KubCmds(CommonCloudFunctions) :
                         obj_attr_list["prov_cloud_ip"] = obj_attr_list["run_cloud_ip"]
 
                 # NOTE: "cloud_ip" is always equal to "run_cloud_ip"
-                obj_attr_list["cloud_ip"] = obj_attr_list["run_cloud_ip"]
+                obj_attr_list["cloud_ip"] = obj_attr_list["run_cloud_ip"] + "_" + obj_attr_list["name"]
                 obj_attr_list["cloud_mac"] = "NA"
                 
                 return True

--- a/scripts/common/cb_common.sh
+++ b/scripts/common/cb_common.sh
@@ -427,7 +427,7 @@ my_ai_name=`get_my_vm_attribute ai_name`
 my_ai_uuid=`get_my_vm_attribute ai`
 my_base_type=`get_my_vm_attribute base_type`
 my_cloud_model=`get_my_vm_attribute model`
-my_ip_addr=`get_my_vm_attribute cloud_ip`
+my_ip_addr=`get_my_vm_attribute run_cloud_ip`
 
 function get_attached_volumes {
     
@@ -832,7 +832,7 @@ function build_ai_mapping {
     for vm in $vmlist
     do
         vmuuid=`echo $vm | cut -d "|" -f 1`
-        vmip=`get_vm_attribute ${vmuuid} cloud_ip`
+        vmip=`get_vm_attribute ${vmuuid} run_cloud_ip`
         vmhn=`get_vm_attribute ${vmuuid} cloud_hostname`
         vmhn=`echo $vmhn | tr '[:upper:]' '[:lower:]'`
         vmrole=`get_vm_attribute ${vmuuid} role`
@@ -849,7 +849,7 @@ function get_ips_from_role {
     vmuuidlist=`get_vm_uuids_from_role ${urole}`
     for vmuuid in $vmuuidlist
     do
-        get_vm_attribute ${vmuuid} cloud_ip
+        get_vm_attribute ${vmuuid} run_cloud_ip
     done
 }
 

--- a/scripts/common/cb_hadoop_common.sh
+++ b/scripts/common/cb_hadoop_common.sh
@@ -508,6 +508,31 @@ EOF
 </property>
 
 <property>
+<name>dfs.datanode.max.xcievers</name>
+<value>16384</value>
+</property>
+
+<property>
+ <name>dfs.datanode.max.transfer.threads</name>
+ <value>16384</value>
+</property>
+
+<property>
+  <name>dfs.namenode.datanode.registration.ip-hostname-check</name>
+  <value>false</value>
+</property>
+
+<property>
+	<name>dfs.client.use.datanode.hostname</name>
+	<value>true</value>
+</property>
+
+<property>
+	<name>dfs.datanode.use.datanode.hostname</name>
+	<value>true</value>
+</property>
+
+<property>
 <name>dfs.datanode.data.dir</name>
 <value>DFS_DATA_DIR</value>
 </property>


### PR DESCRIPTION
k8s presents two additional problems:
1. Because of the way k8s does networking (flannel), applications
that identify themselves by IP address don't work anymore, due
to the way NAT-ing is done in the Kubernetes overlay network.
As a result, applications can only use the names that CB
provides in /etc/hosts

2. Also, for the same reasons, k8s tends to recycle IP addresses a lot,
   after applications are destroyed and re-created. As a result, this causes
   redis tagging conflicts. This means the `cloud_ip` variable has to be
   absolutely unique in Redis.

This commit does the following:

1. Set the required Hadoop XML properties to use names instead of IP addresses.
2. Make sure that the shell scripts use `run_cloud_ip` instead of `cloud_ip`
   to discover each other.
3. Make cloud_ip 100% unique so we don't end up with tagging conflicts.