### PR TITLE
libcloud: ability to log http headers

### DIFF
--- a/lib/clouds/shared_functions.py
+++ b/lib/clouds/shared_functions.py
@@ -275,7 +275,11 @@ class CommonCloudFunctions:
                     obj_attr_list["last_known_state"] = "ACTIVE with (vpn) ip assigned"
                     obj_attr_list["prov_cloud_ip"] = obj_attr_list["cloud_init_vpn"]  
                     cbdebug("VPN address for " + obj_attr_list["log_string"] + " found: " + obj_attr_list["prov_cloud_ip"])                    
-                    _vm_started = True
+                    if obj_attr_list["cloud_ip"] == "undefined" :
+                        cbdebug("Cloud has not finished returning remaining IP information.")
+                        _vm_started = False
+                    else :
+                        _vm_started = True
                 else :
                     obj_attr_list["last_known_state"] = "ACTIVE with (vpn) ip unassigned"
                     cbdebug("VPN address for " + obj_attr_list["log_string"] + " not yet available.")                    


### PR DESCRIPTION
We need the ability to log HTTP headers to debug what happens
with libcloud, but libcloud doesn't make that easy, so we have to
bypass it.

What we're trying to do here is solve a conundrum. Under the covers,
libcloud uses /usr/lib/python2.7/httplib.py as it's primary HTTP
transport library.

httplib, has the ability to debug itself, but instead of using the logging
library like a "good" python library should, it just prints to stdout.
In a separate patch (via Dockerfile) we fix httplib to work correctly
and use a logger.

That being said, after it uses the logging library correctly, we still
have to capture the log output the headers ONLY when something bad happens.
We don't want to spew a bunch of header logs to the logging system
for the 99% of the time when things are working fine.

To solve that problem, we trap the (newly fixed) http header log messages
from the httplib library into a StringIO buffer. Then, if we happen
to hit a python exception in libcloud, we dump those headers to the log
if and only if there is an exception.
