### PR TITLE
kernbench workload

### DIFF
--- a/docker/workload/Dockerfile-ubuntu_cb_kernbench
+++ b/docker/workload/Dockerfile-ubuntu_cb_kernbench
@@ -1,0 +1,17 @@
+FROM REPLACE_NULLWORKLOAD_UBUNTU
+
+# kernbuild-install-pm
+RUN apt-get update
+RUN apt-get install -y build-essential bison flex libelf-dev libssl-dev bc time
+# kernbuild-install-pm
+
+# kernbench-install-git
+RUN cd /home/REPLACE_USERNAME
+RUN git clone https://github.com/linux-test-project/ltp.git -b 20180118
+RUN chmod +x ltp/utils/benchmark/kernbench-0.42/kernbench
+RUN wget -q https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.16.8.tar.xz
+RUN tar xf linux-4.16.8.tar.xz
+RUN mv linux-4.16.8 linux
+# kernbench-install-git
+
+RUN chown -R REPLACE_USERNAME:REPLACE_USERNAME /home/REPLACE_USERNAME

--- a/scripts/kernbench/cb_run_kernbench.sh
+++ b/scripts/kernbench/cb_run_kernbench.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+cd ~
+
+source $(echo $0 | sed -e "s/\(.*\/\)*.*/\1.\//g")/cb_common.sh
+
+set_load_gen $@
+
+LOAD_PROFILE=$(echo ${LOAD_PROFILE} | tr '[:upper:]' '[:lower:]')
+
+KERNBENCH_NR_CPUS=$(get_my_ai_attribute_with_default kernbench_nr_cpus 0)
+KERNBENCH_DATA_DIR=$(get_my_ai_attribute_with_default kernbench_data_dir /kernbench)
+KERNBENCH_PATH=$(get_my_ai_attribute_with_default kernbench_path /foo)
+
+# Override the default 4*cpu for make -j <nr>
+if test $KERNBENCH_NR_CPUS = 0; then
+	NRJOBS=""
+else
+	NRJOBS="-o $KERNBENCH_NR_CPUS"
+fi
+
+CMDLINE="sudo ./kernbenchloadgen.sh $KERNBENCH_PATH $KERNBENCH_DATA_DIR $NRJOBS"
+
+execute_load_generator "${CMDLINE}" ${RUN_OUTPUT_FILE} ${LOAD_DURATION}
+
+elapsed_time=$(grep "Elapsed Time" ${KERNBENCH_PATH}/kernbench.log | awk '{print $3}')
+user_time=$(grep "User Time" ${KERNBENCH_PATH}/kernbench.log | awk '{print $3}')
+system_time=$(grep "System Time" ${KERNBENCH_PATH}/kernbench.log | awk '{print $3}')
+percent_cpu=$(grep "Percent CPU" ${KERNBENCH_PATH}/kernbench.log | awk '{print $3}')
+context_switches=$(grep "Context Switches" ${KERNBENCH_PATH}/kernbench.log | awk '{print $3}')
+sleeps=$(grep "Sleeps" ${KERNBENCH_PATH}/kernbench.log | awk '{print $2}')
+
+~/cb_report_app_metrics.py \
+elapsed_time:$elapsed_time:s \
+user_time:$user_time:s \
+system_time:$system_time:s \
+percent_cpu:$percent_cpu:pc \
+context_switches:$context_switches:nr \
+sleeps:$sleeps:nr \
+$(common_metrics)
+
+echo "~/cb_report_app_metrics.py \
+	elapsed_time:$elapsed_time:s \
+	user_time:$user_time:s \
+	system_time:$system_time:s \
+	percent_cpu:$percent_cpu:pc \
+	context_switches:$context_switches:nr \
+	sleeps:$sleeps:nr \
+	$(common_metrics)" >>/tmp/metrics.txt
+
+rm ${KERNBENCH_PATH}/kernbench.log
+
+unset_load_gen
+
+exit 0

--- a/scripts/kernbench/cb_start_kernbench.sh
+++ b/scripts/kernbench/cb_start_kernbench.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+#/*******************************************************************************
+# Copyright (c) 2012 IBM Corp.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/*******************************************************************************
+
+source $(echo $0 | sed -e "s/\(.*\/\)*.*/\1.\//g")/cb_common.sh
+
+START=`provision_application_start`
+
+syslog_netcat "Start storage setup for kernbench on ${SHORT_HOSTNAME}"
+
+KERNBENCH_DATA_DIR=$(get_my_ai_attribute_with_default kernbench_data_dir /kernbench)
+KERNBENCH_PATH=$(get_my_ai_attribute_with_default kernbench_path /foo)
+mv $KERNBENCH_PATH/linux $KERNBENCH_DATA_DIR/
+sync
+
+syslog_netcat "Storage setup for kernbench on ${SHORT_HOSTNAME} - OK"
+provision_application_stop $START
+exit 0

--- a/scripts/kernbench/dependencies.txt
+++ b/scripts/kernbench/dependencies.txt
@@ -1,0 +1,31 @@
+### START - Dependency installation order ###
+kernbuild-order = 92
+kernbench-order = 93
+### END - Dependency installation order ###
+
+### START - Dependency-specific installation method ###
+# pm = "package manager" (yum or apt-get)
+# sl = "soft link" (assume that the dependency is already installed, just has to
+# be properly exposed to the user's path.
+# git = git clone using above giturl
+# pip = python pip utility
+# man = "manual"
+kernbuild-install = pm
+kernbench-install = git
+### END - Dependency-specific installation method ###
+
+### START - Tests ###
+kernbuild-configure = gcc -v
+kernbench-configure = ls -l ~/ltp/utils/benchmark/kernbench-0.42/kernbench
+### END - Tests ###
+
+### START - Dependency versions ###
+kernbuild-ver = ANY
+kernbench-ver = ANY
+### END - Dependency versions ###
+
+### START -  Dependency and method-specific command lines ###
+
+# AUTOMATICALLY EXTRACTED FROM DOCKERFILE ON ../../docker/workload/
+
+### END -  Dependency and method-specific command lines ###

--- a/scripts/kernbench/kernbenchloadgen.sh
+++ b/scripts/kernbench/kernbenchloadgen.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+KERNBENCH_PATH=$1
+KERNBENCH_DATA_DIR=$2
+NRJOBS=$2
+
+cd ${KERNBENCH_DATA_DIR}/linux
+${KERNBENCH_PATH}/ltp/utils/benchmark/kernbench-0.42/kernbench -n 1 -H -M $NRJOBS
+mv kernbench.log ${KERNBENCH_PATH}

--- a/scripts/kernbench/virtual_application.txt
+++ b/scripts/kernbench/virtual_application.txt
@@ -1,0 +1,38 @@
+# Parameters for this Virtual Application (Application Instance - AI) type should
+# be set on YOUR private configuration configuration file, including the ones
+# commented.
+
+[AI_TEMPLATES : KERNBENCH]
+# Attributes MANDATORY for all Virtual Applications
+SUT = kernbench
+LOAD_BALANCER_SUPPORTED = $False
+RESIZE_SUPPORTED = $True
+REGENERATE_DATA = $True
+LOAD_GENERATOR_ROLE = kernbench
+LOAD_MANAGER_ROLE = kernbench
+METRIC_AGGREGATOR_ROLE = kernbench
+CAPTURE_ROLE = kernbench
+LOAD_PROFILE = default
+LOAD_LEVEL = 1
+LOAD_DURATION = 30
+CATEGORY = synthetic
+PROFILES = default
+REFERENCE = https://github.com/linux-test-project/ltp
+LICENSE = GPL_v2
+REPORTED_METRICS = elapsed_time, user_time, system_time, percent_cpu, context_switches, sleeps
+
+# VApp-specific MANDATORY attributes
+DESCRIPTION =Deploys a single instance and runs the "kernbench" synthetic benchmark\n
+DESCRIPTION +=  - LOAD_PROFILE possible values: _PROFILES_.\n
+DESCRIPTION +=  - LOAD_LEVEL meaning: number of jobs running in parallel, currently only 1 is supported.\n
+DESCRIPTION +=  - LOAD_DURATION meaning: not used, a run ends when a specific\n
+DESCRIPTION +=    number of I/O operations is reached.\n
+KERNBENCH_SETUP1 = cb_start_kernbench.sh
+START = cb_run_kernbench.sh
+
+# VApp-specific modifier parameters. Commented attributes imply default values assumed
+# NR_CPUS = 0 means use kernbench "optimal runs": 4*cpu
+KERNBENCH_NR_CPUS = 0
+KERNBENCH_PATH = ~/foo
+KERNBENCH_DATA_DIR = /kernbench
+KERNBENCH_DATA_FSTYP = ext4


### PR DESCRIPTION
Add the kernbench workload, each run cleans up the tree, make a
defconfig and then compile the kernel with the specified amount of
compiler threads (default is 4 * cpus).

Signed-off-by: Julien Desfossez <jdesfossez@digitalocean.com>