### PR TITLE
Support for service accounts

### DIFF
--- a/configs/templates/internal_options.txt
+++ b/configs/templates/internal_options.txt
@@ -214,6 +214,10 @@ PREPARE_IMAGE_NAME = None
 NEST_CONTAINERS_ENABLED = $False
 NEST_CONTAINERS_REPOSITORY = ibmcb
 NEST_CONTAINERS_INSECURE_REGISTRY = $False
+CLOUDINIT_SUDO_USER = cbtool
+# Use the 'openssl' command to choose a password to enable this feature.
+# Requires cloud-init support.
+CLOUDINIT_SUDO_PASSWD = $False # Disabled
 
 [AI_DEFAULTS]
 USERNAME = $MAIN_USERNAME

--- a/lib/clouds/shared_functions.py
+++ b/lib/clouds/shared_functions.py
@@ -1090,6 +1090,14 @@ class CommonCloudFunctions:
             return None
 
         cloudconfig = "#cloud-config\n"
+
+        if "cloudinit_sudo_passwd" in obj_attr_list and str(obj_attr_list["cloudinit_sudo_passwd"]).lower() != "false" and "cloudinit_sudo_user" in obj_attr_list :
+               cloudconfig += "users:\n"
+               cloudconfig += "- name: " + obj_attr_list["cloudinit_sudo_user"] + "\n"
+               cloudconfig += "  lock-passwd: false\n"
+               cloudconfig += "  lock_passwd: false\n"
+               cloudconfig += "  passwd: " + obj_attr_list["cloudinit_sudo_passwd"].replace("DOLLAR", "$") + "\n"
+               cloudconfig += "  sudo: ALL=(ALL) NOPASSWD:ALL\n"
         
         if obj_attr_list["userdata_ssh"].lower() == "true" :
 #            cloudconfig += "disable_root: false\n"            


### PR DESCRIPTION
After a snapshot is created, often we still need to attach to a VM's serial console, but sometimes we want a username to be installed with sudo access in the VM without requiring network access to create that user.

As long as we have cloud-init, we can do that on the fly, regardless how old the snapshot is.

Example:

 > CLOUDINIT_SUDO_USER = cbtool
 > +# Use the 'openssl' command to choose a password to enable this feature. 
 > +# Requires cloud-init support.
 > +CLOUDINIT_SUDO_PASSWD = $False # Disabled by default

Instead of `False`, you just input a salted password (example using the openssl command) just like you would in the shadow file.

This allows the user to choose (at boot time) whatever service account for debugging purposes that they want without having to ask for the snapshot to be regenerated.
