### PR TITLE
Improvements for JAVA-based workloads

### DIFF
--- a/scripts/cassandra_ycsb/virtual_application.txt
+++ b/scripts/cassandra_ycsb/virtual_application.txt
@@ -50,6 +50,7 @@ START=cb_run_ycsb.sh
 
 # VApp-specific OPTIONAL modifier parameters. Commented attributes imply default values assumed
 JAVA_HOME = auto
+JAVA_VER = 7
 JVM_STACK_SIZE = 1024k
 READ_RATIO = workloaddefault
 UPDATE_RATIO = workloaddefault

--- a/scripts/giraph/virtual_application.txt
+++ b/scripts/giraph/virtual_application.txt
@@ -45,10 +45,16 @@ START = cb_run_giraph.sh
 
 # VApp-specific modifier parameters. Commented attributes imply default values assumed
 JAVA_HOME = auto
+JAVA_VER = 7
 HADOOP_HOME = ~/hadoop-1.2.1
 HADOOP_EXAMPLES = hadoop-examples-1.2.1.jar
-DFS_NAME_DIR = /tmp/cbhadoopname
-DFS_DATA_DIR = /tmp/cbhadoopdata
+DFS_NAME_DIR = /dfs/cbhadoopname
+DFS_DATA_DIR = /dfs/cbhadoopdata
+REPLICATION_FACTOR = 3
+GIRAPHSLAVE_DATA_FSTYP = ext4
+GIRAPHSLAVE_DATA_DIR = /dfs
+GIRAPHMASTER_DATA_FSTYP = ext4
+GIRAPHMASTER_DATA_DIR = /dfs
 GIRAPH_HOME = ~/giraph/
 ZOOKEEPER_HOME=~/giraph/zookeeper/zookeeper-3.4.6/
 EDGES_PER_VERTEX = 3

--- a/scripts/hadoop/virtual_application.txt
+++ b/scripts/hadoop/virtual_application.txt
@@ -48,14 +48,17 @@ START = cb_run_hadoop.sh
 
 # VApp-specific modifier parameters.
 JAVA_HOME = auto
-HADOOP_HOME = ~/hadoop-2.6.0
+JAVA_VER = 7
+HADOOP_HOME = ~/hadoop-2.6.1
 HADOOP_EXAMPLES = share/hadoop/mapreduce/hadoop-mapreduce-examples-VERSION.jar
 HIBENCH_HOME = ~/HiBench
-DFS_NAME_DIR = /tmp/cbhadoopname
+DFS_NAME_DIR = /dfs/cbhadoopname
+DFS_DATA_DIR = /dfs/cbhadoopdata
+REPLICATION_FACTOR = 3
 HADOOPSLAVE_DATA_FSTYP = ext4
-HADOOPSLAVE_DATA_DIR = /tmp/cbhadoopdata
+HADOOPSLAVE_DATA_DIR = /dfs
 HADOOPMASTER_DATA_FSTYP = ext4
-HADOOPMASTER_DATA_DIR = /tmp/cbhadoopdata
+HADOOPMASTER_DATA_DIR = /dfs
 LOAD_FACTOR = 10000
 CLASSES = 20
 NUM_MAPS = 2

--- a/scripts/mongo_acmeair/virtual_application.txt
+++ b/scripts/mongo_acmeair/virtual_application.txt
@@ -42,13 +42,14 @@ MONGO_CFG_SERVER_RESIZE1 = cb_modify_hosts.sh
 START = cb_run_acme.sh
 
 # VApp-specific modifier parameters. Commented attributes imply default values assumed
+JAVA_HOME = auto
+JAVA_VER = 8
 # ACMEAIR_PATH = ~/acmeair-monolithic-java
 # ACMEAIR_PROPERTIES = ~/acmeair.properties
 # ACMEAIR_DRIVER_PATH = ~/acmeair-driver
 # ACMEAIR_DRIVER_RAMPUP_TIME = 10
 # ACMEAIR_HTTP_PORT = 9085
 # ACMEAIR_HTTPS_PORT = 9485
-# JAVA_HOME = auto
 # WLP_SERVERDIR = /opt/ibm/wlp
 # NUM_CUSTOMERS = 1000
 

--- a/scripts/mongo_ycsb/virtual_application.txt
+++ b/scripts/mongo_ycsb/virtual_application.txt
@@ -43,6 +43,8 @@ MONGO_CFG_SERVER_RESIZE1 = cb_modify_hosts.sh
 START = cb_run_ycsb.sh
 
 # VApp-specific modifier parameters. Commented attributes imply default values assumed
+JAVA_HOME = auto
+JAVA_VER = 7
 APP_COLLECTION = lazy
 RUN_COUNTER_NAME = experiment_id_counter
 MONGODB_DATA_DIR = /dbstore

--- a/scripts/open_daytrader/virtual_application.txt
+++ b/scripts/open_daytrader/virtual_application.txt
@@ -52,6 +52,7 @@ START = cb_run_daytrader.sh
 
 # VApp-specific modifier parameters. Commented attributes imply default values assumed
 JAVA_HOME = auto
+JAVA_VER = 7
 JAVA_MAX_MEM_HEAP = 0.8
 JAVA_EXTRA_CMD_OPTS = -Xms256m
 NR_QUOTES=4000

--- a/scripts/redis_ycsb/virtual_application.txt
+++ b/scripts/redis_ycsb/virtual_application.txt
@@ -42,6 +42,8 @@ YCSB_SETUP2 = cb_setup_ycsb.sh
 START = cb_run_ycsb.sh
 
 # VApp-specific modifier parameters. Commented attributes imply default values assumed
+JAVA_HOME = auto
+JAVA_VER = 7
 READ_RATIO = workloaddefault
 UPDATE_RATIO = workloaddefault
 APP_COLLECTION = lazy

--- a/scripts/scimark/virtual_application.txt
+++ b/scripts/scimark/virtual_application.txt
@@ -31,6 +31,7 @@ START = cb_run_scimark.sh
 
 # VApp-specific modifier parameters. Commented attributes imply default values assumed
 JAVA_HOME = auto
+JAVA_VER = 7
 
 # Inter-Virtual Application instances (inter-AI) synchronized execution. Entirely optional
 #SYNC_COUNTER_NAME = synchronization_counter

--- a/scripts/specjbb/virtual_application.txt
+++ b/scripts/specjbb/virtual_application.txt
@@ -34,6 +34,7 @@ START = cb_run_specjbb.sh
 
 # VApp-specific modifier parameters.
 JAVA_HOME = auto
+JAVA_VER = 7
 JAVA_MAX_MEM_HEAP = 0.8
 JAVA_EXTRA_CMD_OPTS = -Xms256m
 LOAD_FACTOR = 1000


### PR DESCRIPTION
Make sure the function `set_java_home` in common does not break even
when JAVA_HOME is set to "auto" (the default) and the function is
executed in an image where multiple versions of JAVA are installed.
We do that by basically allowing the specification a new attribute
JAVA_VER, which is used by the function to determine the correct path.
This problem is particularly relevant on newer versions of Ubuntu,
where installing JAVA 7, required by some workloads, will bring JAVA 11.
In addition to it, some minor improvements for Haddop workloads were
added. In particular, it makes sure that the hadoop data directories
will be appropriately mounted on data volumes, where these are made
available.