### PR TITLE
Fix for bonnie

### DIFF
--- a/scripts/bonnie/cb_run_bonnie.sh
+++ b/scripts/bonnie/cb_run_bonnie.sh
@@ -49,14 +49,14 @@ lat_r_block=$(cat ${RUN_OUTPUT_FILE} | tail -1 | cut -d ',' -f 41)
 lat_rand_block=$(cat ${RUN_OUTPUT_FILE} | tail -1 | cut -d ',' -f 42)
 
 echo $tp_w_block | grep +++
-is_tp_w_block_err=$?
+is_tp_w_block_ok=$?
 
 echo $tp_r_block | grep +++
-is_tp_r_block_err=$?
+is_tp_r_block_ok=$?
 
 LATENCY=$(echo "scale=2; ($lat_w_block + $lat_r_block)/2" | sed 's/us//g' | sed 's/ms//g' | bc -l)
 
-if [[ $is_tp_w_block_err -eq 0 && $is_tp_r_block_err -eq 0 ]]
+if [[ $is_tp_w_block_ok -eq 1 && $is_tp_r_block_ok -eq 1 ]]
 then
     TPUT=$(echo "scale=2; ($tp_w_block + $tp_r_block)/2" | bc -l)
 fi


### PR DESCRIPTION
Make sure the function `set_java_home` in common does not break even
when JAVA_HOME is set to "auto" (the default) and the function is
executed in an image where multiple versions of JAVA are installed.
We do that by basically allowing the specification a new attribute
JAVA_VER, which is used by the function to determine the correct path.
This problem is particularly relevant on newer versions of Ubuntu,
where installing JAVA 7, required by some workloads, will bring JAVA 11.
In addition to it, some minor improvements for Haddop workloads were
added. In particular, it makes sure that the hadoop data directories
will be appropriately mounted on data volumes, where these are made
available.