### PR TITLE
Fixes for Cassandra/YCSB

### DIFF
--- a/scripts/cassandra_ycsb/cb_restart_seed.sh
+++ b/scripts/cassandra_ycsb/cb_restart_seed.sh
@@ -69,8 +69,20 @@ fi
 if [[ $(grep -c "LOCAL_JMX=no" ${CASSANDRA_CONF_DIR}/cassandra-env.sh) -eq 0 ]]
 then
     LINE_NUMBER=$(sudo grep -n LOCAL_JMX=yes ${CASSANDRA_CONF_DIR}/cassandra-env.sh | cut -d ':' -f 1)
+    if [[ -z $LINE_NUMBER ]]
+    then
+        LINE_NUMBER=$(sudo grep -n JMX_PORT= ${CASSANDRA_CONF_DIR}/cassandra-env.sh | cut -d ':' -f 1)
+    fi        
     LINE_NUMBER=$((LINE_NUMBER-2))
     sudo sed -i -e "${LINE_NUMBER}i\LOCAL_JMX=no" ${CASSANDRA_CONF_DIR}/cassandra-env.sh
+fi
+
+if [[ $(grep -c "JAVA_HOME=" /etc/init.d/cassandra) -eq 0 ]]
+then
+    LINE_NUMBER=$(sudo grep -n "# Export JAVA_HOME, if set." /etc/init.d/cassandra | cut -d ':' -f 1)
+    LINE_NUMBER=$((LINE_NUMBER-2))
+    sudo sed -i -e "${LINE_NUMBER}i\JAVA_HOME=${JAVA_HOME}" /etc/init.d/cassandra
+    systemctl daemon-reload
 fi
 
 pos=1

--- a/scripts/cassandra_ycsb/virtual_application.txt
+++ b/scripts/cassandra_ycsb/virtual_application.txt
@@ -50,6 +50,7 @@ START=cb_run_ycsb.sh
 
 # VApp-specific OPTIONAL modifier parameters. Commented attributes imply default values assumed
 JAVA_HOME = auto
+JAVA_VER = 7
 JVM_STACK_SIZE = 1024k
 READ_RATIO = workloaddefault
 UPDATE_RATIO = workloaddefault


### PR DESCRIPTION
Make sure the function `set_java_home` in common does not break even
when JAVA_HOME is set to "auto" (the default) and the function is
executed in an image where multiple versions of JAVA are installed.
We do that by basically allowing the specification a new attribute
JAVA_VER, which is used by the function to determine the correct path.
This problem is particularly relevant on newer versions of Ubuntu,
where installing JAVA 7, required by some workloads, will bring JAVA 11.
In addition to it, some minor improvements for Haddop workloads were
added. In particular, it makes sure that the hadoop data directories
will be appropriately mounted on data volumes, where these are made
available.