### PR TITLE
Fixes for Filebench

### DIFF
--- a/scripts/filebench/cb_run_filebench.sh
+++ b/scripts/filebench/cb_run_filebench.sh
@@ -40,6 +40,15 @@ sed -i "s^FILEBENCH_DATA_DIR^$FILEBENCH_DATA_DIR^g" ${PERSONALITY_FILE}
 sed -i "s^LOAD_DURATION^$LOAD_DURATION^g" ${PERSONALITY_FILE}
 sed -i "s^usage \"^#usage \"^g" ${PERSONALITY_FILE}
 
+if [[ $(sudo cat /etc/*release* | grep DISTRIB_RELEASE | cut -d '=' -f 2) == "18.04" ]]
+then
+    echo 0 | sudo tee /proc/sys/kernel/randomize_va_space >/dev/null 2>&1
+    if [[ $(sudo cat /proc/sys/kernel/randomize_va_space) -ne 0 ]]
+    then
+        syslog_netcat "\"/proc/sys/kernel/randomize_va_space\" in non-zero. Filebench will hang!"
+    fi
+fi
+
 CMDLINE="sudo ${filebench} -f ${PERSONALITY_FILE}"
 
 execute_load_generator "${CMDLINE}" ${RUN_OUTPUT_FILE} ${LOAD_DURATION}


### PR DESCRIPTION
Make sure the function `set_java_home` in common does not break even
when JAVA_HOME is set to "auto" (the default) and the function is
executed in an image where multiple versions of JAVA are installed.
We do that by basically allowing the specification a new attribute
JAVA_VER, which is used by the function to determine the correct path.
This problem is particularly relevant on newer versions of Ubuntu,
where installing JAVA 7, required by some workloads, will bring JAVA 11.
In addition to it, some minor improvements for Haddop workloads were
added. In particular, it makes sure that the hadoop data directories
will be appropriately mounted on data volumes, where these are made
available.