### PR TITLE
Fixes for Kernbench

### DIFF
--- a/scripts/kernbench/cb_run_kernbench.sh
+++ b/scripts/kernbench/cb_run_kernbench.sh
@@ -8,13 +8,17 @@ set_load_gen $@
 
 LOAD_PROFILE=$(echo ${LOAD_PROFILE} | tr '[:upper:]' '[:lower:]')
 
-KERNBENCH_NR_CPUS=$(get_my_ai_attribute_with_default kernbench_nr_cpus 0)
+KERNBENCH_NR_CPUS=$(get_my_ai_attribute_with_default kernbench_nr_cpus auto)
 KERNBENCH_DATA_DIR=$(get_my_ai_attribute_with_default kernbench_data_dir /kernbench)
-KERNBENCH_PATH=$(get_my_ai_attribute_with_default kernbench_path /foo)
+KERNBENCH_PATH=$(get_my_ai_attribute_with_default kernbench_path ~/foo)
+eval KERNBENCH_PATH=${KERNBENCH_PATH}
+
+linux_distribution
 
 # Override the default 4*cpu for make -j <nr>
-if test $KERNBENCH_NR_CPUS = 0; then
-	NRJOBS=""
+if [[ $KERNBENCH_NR_CPUS == "auto" ]]
+then
+	NRJOBS="-o $((NR_CPUS*4))"
 else
 	NRJOBS="-o $KERNBENCH_NR_CPUS"
 fi
@@ -37,18 +41,10 @@ system_time:$system_time:s \
 percent_cpu:$percent_cpu:pc \
 context_switches:$context_switches:nr \
 sleeps:$sleeps:nr \
+latency:$elapsed_time:s \
 $(common_metrics)
 
-echo "~/cb_report_app_metrics.py \
-	elapsed_time:$elapsed_time:s \
-	user_time:$user_time:s \
-	system_time:$system_time:s \
-	percent_cpu:$percent_cpu:pc \
-	context_switches:$context_switches:nr \
-	sleeps:$sleeps:nr \
-	$(common_metrics)" >>/tmp/metrics.txt
-
-rm ${KERNBENCH_PATH}/kernbench.log
+rm -rf ${KERNBENCH_PATH}/kernbench.log
 
 unset_load_gen
 

--- a/scripts/kernbench/cb_start_kernbench.sh
+++ b/scripts/kernbench/cb_start_kernbench.sh
@@ -23,8 +23,10 @@ START=`provision_application_start`
 syslog_netcat "Start storage setup for kernbench on ${SHORT_HOSTNAME}"
 
 KERNBENCH_DATA_DIR=$(get_my_ai_attribute_with_default kernbench_data_dir /kernbench)
-KERNBENCH_PATH=$(get_my_ai_attribute_with_default kernbench_path /foo)
-mv $KERNBENCH_PATH/linux $KERNBENCH_DATA_DIR/
+KERNBENCH_PATH=$(get_my_ai_attribute_with_default kernbench_path ~/foo)
+eval KERNBENCH_PATH=${KERNBENCH_PATH}
+
+rsync -az --inplace --delete $KERNBENCH_PATH/linux/ $KERNBENCH_DATA_DIR/linux/
 sync
 
 syslog_netcat "Storage setup for kernbench on ${SHORT_HOSTNAME} - OK"

--- a/scripts/kernbench/virtual_application.txt
+++ b/scripts/kernbench/virtual_application.txt
@@ -15,11 +15,11 @@ CAPTURE_ROLE = kernbench
 LOAD_PROFILE = default
 LOAD_LEVEL = 1
 LOAD_DURATION = 30
-CATEGORY = synthetic
+CATEGORY = application-stress
 PROFILES = default
 REFERENCE = https://github.com/linux-test-project/ltp
 LICENSE = GPL_v2
-REPORTED_METRICS = elapsed_time, user_time, system_time, percent_cpu, context_switches, sleeps
+REPORTED_METRICS = latency, elapsed_time, user_time, system_time, percent_cpu, context_switches, sleeps
 
 # VApp-specific MANDATORY attributes
 DESCRIPTION =Deploys a single instance and runs the "kernbench" synthetic benchmark\n
@@ -31,8 +31,8 @@ KERNBENCH_SETUP1 = cb_start_kernbench.sh
 START = cb_run_kernbench.sh
 
 # VApp-specific modifier parameters. Commented attributes imply default values assumed
-# NR_CPUS = 0 means use kernbench "optimal runs": 4*cpu
-KERNBENCH_NR_CPUS = 0
+# NR_CPUS = auto means use kernbench "optimal runs": 4*cpu
+KERNBENCH_NR_CPUS = auto
 KERNBENCH_PATH = ~/foo
 KERNBENCH_DATA_DIR = /kernbench
 KERNBENCH_DATA_FSTYP = ext4


### PR DESCRIPTION
Make sure the function `set_java_home` in common does not break even
when JAVA_HOME is set to "auto" (the default) and the function is
executed in an image where multiple versions of JAVA are installed.
We do that by basically allowing the specification a new attribute
JAVA_VER, which is used by the function to determine the correct path.
This problem is particularly relevant on newer versions of Ubuntu,
where installing JAVA 7, required by some workloads, will bring JAVA 11.
In addition to it, some minor improvements for Haddop workloads were
added. In particular, it makes sure that the hadoop data directories
will be appropriately mounted on data volumes, where these are made
available.