### PR TITLE
Fix for issue #271

### DIFF
--- a/docker/build_common.sh
+++ b/docker/build_common.sh
@@ -53,7 +53,7 @@ fi
 
 CB_RSYNC=$CB_RSYNC_ADDR:${CB_RSYNC_PORT}/$(whoami)_cb
 echo "##### Testing rsync server on $CB_RSYNC..." 
-rsync -a rsync://${CB_RSYNC}/3rd_party/pypureomapi*tar.gz > /dev/null 2>&1
+rsync -a rsync://${CB_RSYNC}/util/cbssh.sh > /dev/null 2>&1
 if [[ $? -ne 0 ]]
 then
     echo "Error while testing rsync server"

--- a/kvm-qemu/build_common.sh
+++ b/kvm-qemu/build_common.sh
@@ -73,7 +73,7 @@ fi
 CB_RSYNC=$CB_RSYNC_ADDR-${CB_RSYNC_PORT}-$(whoami)
 CB_RSYNC_DIRECT=${CB_RSYNC_ADDR}:${CB_RSYNC_PORT}/$(whoami)_cb    
 echo "##### Testing rsync server on ${CB_RSYNC_DIRECT}..." 
-rsync -a rsync://${CB_RSYNC_DIRECT}/3rd_party/pypureomapi*tar.gz > /dev/null 2>&1
+rsync -a rsync://${CB_RSYNC_DIRECT}/util/cbssh.sh > /dev/null 2>&1
 if [[ $? -ne 0 ]]
 then
     echo "Error while testing rsync server"

--- a/scripts/sysbench/cb_restart_mysql.sh
+++ b/scripts/sysbench/cb_restart_mysql.sh
@@ -25,7 +25,7 @@ MYSQL_NONROOT_USER=`get_my_ai_attribute_with_default mysql_nonroot_user sysbench
 MYSQL_NONROOT_PASSWORD=`get_my_ai_attribute_with_default mysql_nonroot_password sysbench`
 MYSQL_DATA_DIR=`get_my_ai_attribute_with_default mysql_data_dir /sysbench`
 MYSQL_CONF_FILE=`get_my_ai_attribute_with_default mysql_conf_file /etc/mysql/mysql.conf.d/mysqld.cnf`
-MYSQL_RAM_PERCENTAGE=`get_my_ai_attribute_with_default mysql_ram_percentage 70`
+#MYSQL_RAM_PERCENTAGE=`get_my_ai_attribute_with_default mysql_ram_percentage 10`
 
 SHORT_HOSTNAME=$(uname -n| cut -d "." -f 1)
 NETSTAT_CMD=`which netstat`
@@ -48,9 +48,9 @@ fi
 ${SUDO_CMD} sed -i "s^bind-address.*^bind-address            = $my_ip_addr^g" ${MYSQL_CONF_FILE}
 
 # Set mysql's memory cache size to be a percentage of main memory
-kb=$(cat /proc/meminfo  | sed -e "s/ \+/ /g" | grep MemTotal | cut -d " " -f 2)
-mb=$(echo "$kb / 1024 * ${MYSQL_RAM_PERCENTAGE} / 100" | bc)
-${SUDO_CMD} su -c "echo 'innodb_buffer_pool_size = ${mb}M' >> ${MYSQL_CONF_FILE}"
+#kb=$(cat /proc/meminfo  | sed -e "s/ \+/ /g" | grep MemTotal | cut -d " " -f 2)
+#mb=$(echo "$kb / 1024 * ${MYSQL_RAM_PERCENTAGE} / 100" | bc)
+#${SUDO_CMD} su -c "echo 'innodb_buffer_pool_size = ${mb}M' >> ${MYSQL_CONF_FILE}"
 
 if [[ $(${SUDO_CMD} ls /etc/apparmor.d/tunables/ | grep -c alias) -ne 0 ]]
 then

--- a/scripts/sysbench/virtual_application.txt
+++ b/scripts/sysbench/virtual_application.txt
@@ -13,11 +13,11 @@ LOAD_GENERATOR_ROLE = sysbench
 LOAD_MANAGER_ROLE = sysbench
 METRIC_AGGREGATOR_ROLE = sysbench
 CAPTURE_ROLE = mysql
-LOAD_PROFILE = complex
+LOAD_PROFILE = oltp_read_write
 LOAD_LEVEL = uniformIXIXI1I5
 LOAD_DURATION = 30
 CATEGORY = transactional
-PROFILES = simple,complex,nontrx,sp
+PROFILES = bulk_insert,oltp_delete,oltp_insert,oltp_point_select,oltp_read_only,oltp_read_write,oltp_update_index,oltp_update_non_index,oltp_write_only,select_random_points,select_random_ranges
 REFERENCE = https://github.com/akopytov/sysbench
 LICENSE = GPL_v2
 REPORTED_METRICS = throughput,latency,95_latency,datagen_time,datagen_size,completion_time,errors,quiescent_time
@@ -25,7 +25,7 @@ REPORTED_METRICS = throughput,latency,95_latency,datagen_time,datagen_size,compl
 # VApp-specific MANDATORY attributes
 DESCRIPTION =Deploys an instance running the sysbench (OLTP) load generator and\n
 DESCRIPTION +=one instance running MySQL database.\n
-DESCRIPTION +=  - LOAD_PROFILE possible values: _PROFILES_ (parameter --oltp-test-mode)\n
+DESCRIPTION +=  - LOAD_PROFILE possible values: _PROFILES_ (parameter /usr/share/sysbench/*.lua)\n
 DESCRIPTION +=  - LOAD_LEVEL meaning: number of threads on sysbench (parameter --num-threads).\n 
 DESCRIPTION +=  - LOAD_DURATION meaning: for how long should sysbench run.\n
 
@@ -40,7 +40,6 @@ MYSQL_ROOT_PASSWORD = temp4now
 MYSQL_NONROOT_USER = sysbench
 MYSQL_NONROOT_PASSWORD = sysbench
 TABLE_SIZE = 10000
-READ_ONLY = off
 # Probably ubuntu-specific. May need to override for CentOS
 MYSQL_CONF_FILE = /etc/mysql/mysql.conf.d/mysqld.cnf
 # Default to 70% of main memory


### PR DESCRIPTION
Make sure the function `set_java_home` in common does not break even
when JAVA_HOME is set to "auto" (the default) and the function is
executed in an image where multiple versions of JAVA are installed.
We do that by basically allowing the specification a new attribute
JAVA_VER, which is used by the function to determine the correct path.
This problem is particularly relevant on newer versions of Ubuntu,
where installing JAVA 7, required by some workloads, will bring JAVA 11.
In addition to it, some minor improvements for Haddop workloads were
added. In particular, it makes sure that the hadoop data directories
will be appropriately mounted on data volumes, where these are made
available.