### PR TITLE
Fully deterministic round-robin scheduling

### DIFF
--- a/lib/auxiliary/data_ops.py
+++ b/lib/auxiliary/data_ops.py
@@ -27,6 +27,7 @@ from time import time, strftime, strptime, localtime
 from os import chmod
 from random import random
 from datetime import datetime
+from re import sub, split
 
 from ..auxiliary.code_instrumentation import trace, cbdebug, cberr, cbwarn, cbinfo, cbcrit
 
@@ -604,3 +605,9 @@ def value_cleanup(object_dict, unit) :
     _val_string = _val_string[0:-3]
             
     return _val_string
+
+def natural_keys(text):
+  def atoi(text):
+    return int(text) if text.isdigit() else text
+
+  return [ atoi(c) for c in split(r'(\d+)', text) ]

--- a/lib/operations/base_operations.py
+++ b/lib/operations/base_operations.py
@@ -2169,7 +2169,6 @@ class BaseObjectOperations :
             else :
                 obj_attr_list["load_balancer_target_role"] = "none"
 
-            _vm_nr = 1
             _cloud_ips = {}
             for _tier_nr in range(0, len(_tiers)) :
 
@@ -2204,6 +2203,7 @@ class BaseObjectOperations :
                     _pobj_uuid = _pobj_uuid.upper()
                     obj_attr_list["vms"] += _pobj_uuid + ','
                     obj_attr_list["parallel_operations"][_vm_counter]["uuid"] = _pobj_uuid
+                    obj_attr_list["parallel_operations"][_vm_counter]["placement_order"] = _vm_counter
                     obj_attr_list["parallel_operations"][_vm_counter]["ai"] = obj_attr_list["uuid"]
                     obj_attr_list["parallel_operations"][_vm_counter]["ai_name"] = obj_attr_list["name"]
                     obj_attr_list["parallel_operations"][_vm_counter]["aidrs"] = obj_attr_list["aidrs"]


### PR DESCRIPTION
We've had round-robin provisionig for a while, but it was not deterministic,
meaning that if you reset CB, the next time you create a batch of VMs,
there was no gaurantee the same VMs would go to the same places.

The commit makes it so that VMCs are sorted and then assigned VMs to them
in such a way that the head-VM of the the AI always goes first followed by
the remaining VMs in the AI in the same order in which they were assigned.

This is really important when you have a cluster of heterogeneous hypervisors
that have different sizes or different performance characteristics and
you want things to perform in the same way each time.