### PR TITLE
Cleanup libcloud image identification

### DIFF
--- a/lib/clouds/do_cloud_ops.py
+++ b/lib/clouds/do_cloud_ops.py
@@ -52,9 +52,9 @@ class DoCmds(LibcloudCmds) :
         # arbitrary length. At best we can detect whether or not they
         # are integers, but the number of digits is never a guarantee.
 
-        if is_number(imageid) :
-            return True
-        return False
+        # DigitalOcean also supports regularly-named images.
+        # Just return true unconditionally.
+        return True
 
     @trace            
     def create_ssh_key(self, vmc_name, key_name, key_type, key_contents, key_fingerprint, vm_defaults, connection) :

--- a/lib/clouds/libcloud_common.py
+++ b/lib/clouds/libcloud_common.py
@@ -926,7 +926,12 @@ class LibcloudCmds(CommonCloudFunctions) :
             
             if self.is_cloud_image_uuid(obj_attr_list["imageid1"]) :
                 if self.use_get_image :
-                    _candidate_images = self.get_adapter(obj_attr_list["credentials_list"]).get_image(obj_attr_list["imageid1"])
+                    try :
+                        _candidate_images = self.get_adapter(obj_attr_list["credentials_list"]).get_image(obj_attr_list["imageid1"])
+                    except BaseHTTPError, e :
+                        if e.code == 404 :
+                            cbdebug("Instead looking for: " + obj_attr_list["imageid1"].replace("_", " "), True)
+                            _candidate_images = self.get_adapter(obj_attr_list["credentials_list"]).get_image(obj_attr_list["imageid1"].replace("_", " "))
                 else :
                     for _image in self.get_adapter(obj_attr_list["credentials_list"]).list_images() :
                         if _image.id == obj_attr_list["imageid1"] :


### PR DESCRIPTION
DigitalOcean in particular supports both names and IDs as image identifiers.

Additionally, if we issue a `cldalter` to change the image ID on the fly,
we need to be able to lookup that modified image ID without having to
reset CloudBench to be able to use it.