### PR TITLE
workload changes: cassandra and containers

### DIFF
--- a/scripts/cassandra_ycsb/virtual_application.txt
+++ b/scripts/cassandra_ycsb/virtual_application.txt
@@ -70,6 +70,8 @@ DATABASE_SIZE_VERSUS_MEMORY = 0.5
 REPLICATION_FACTOR = 3
 LOAD_THREADS = 8
 DROP_KEYSPACE = 1
+# 50% for cassandra. Docs recommend leaving a lot available for page cache
+SEED_RAM_PERCENTAGE = 50
 
 # Inter-Virtual Application instances (inter-AI) synchronized execution. Entirely optional
 #SYNC_COUNTER_NAME = synchronization_counter

--- a/scripts/common/cb_common.sh
+++ b/scripts/common/cb_common.sh
@@ -39,6 +39,7 @@ RANGE=60
 ATTEMPTS=3
 
 SETUP_TIME=20
+SUDO_CMD=`which sudo`
 
 NEST_EXPORTED_HOME="/tmp/userhome"
 
@@ -1395,7 +1396,7 @@ function replicate_to_container_if_nested {
     syslog_netcat "Container started, settling..."
 
     # Figure out when the container is ready
-    ATTEMPTS=100
+    ATTEMPTS=400
     while true ; do
         out=$(sudo docker exec -u ${username} --privileged cbnested bash -c "if [ x\"\$(ps -ef | grep sshd | grep -v grep)\" != x ] ; then exit 0 ; else exit 2 ; fi" 2>&1)
         rc=$?
@@ -1468,7 +1469,6 @@ function post_boot_steps {
 
     SHORT_HOSTNAME=$(uname -n| cut -d "." -f 1)
     KILL_CMD=`which killall`
-    SUDO_CMD=`which sudo`
     export PATH=$PATH:/sbin
     PIDOF_CMD=`which pidof`
 

--- a/scripts/common/cb_post_boot.sh
+++ b/scripts/common/cb_post_boot.sh
@@ -42,19 +42,20 @@ syslog_netcat "Starting generic VM post_boot configuration"
 linux_distribution
 setup_passwordless_ssh
 
+syslog_netcat "Relaxing all security configurations"
+security_configuration
+
 load_manager_vm_uuid=`get_my_ai_attribute load_manager_vm`
 
 if [[ x"${my_vm_uuid}" == x"${load_manager_vm_uuid}" || x"${my_type}" == x"none" ]]
 then
-    syslog_netcat "Relaxing all security configurations"
-    security_configuration
     syslog_netcat "Starting (AI) Log store..."
     start_syslog `get_global_sub_attribute logstore port`
     syslog_netcat "Local (AI) Log store started"
     syslog_netcat "Starting (AI) Object store..."
     start_redis ${osportnumber}
     syslog_netcat "Local (AI) Object store started"
-    setup_rclocal_restarts
+	setup_rclocal_restarts
 fi
 
 refresh_hosts_file


### PR DESCRIPTION
1. Sometimes pulling large container images take a long time. Wait a bit longer.
2. Cassandra now has a configurable memory limit, which defaults to 50%.