### PR TITLE
Update spec workload containers

### DIFF
--- a/docker/workload/Dockerfile-ubuntu_cb_hadoop
+++ b/docker/workload/Dockerfile-ubuntu_cb_hadoop
@@ -1,15 +1,12 @@
 FROM REPLACE_NULLWORKLOAD_UBUNTU
 
 # java-install-pm
-RUN apt-get update; mkdir /home/REPLACE_USERNAME/openjdk7/ ; wget -N -q -P /home/REPLACE_USERNAME/openjdk7/ http://ftp.us.debian.org/debian/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_1.5.2-2+b1_REPLACE_ARCH3.deb
-RUN wget -N -q -P /home/REPLACE_USERNAME/openjdk7/ http://ftp.us.debian.org/debian/pool/main/o/openjdk-7/openjdk-7-jre-headless_7u161-2.6.12-1_REPLACE_ARCH3.deb
-RUN wget -N -q -P /home/REPLACE_USERNAME/openjdk7/ http://ftp.us.debian.org/debian/pool/main/o/openjdk-7/openjdk-7-jre_7u161-2.6.12-1_REPLACE_ARCH3.deb
-RUN wget -N -q -P /home/REPLACE_USERNAME/openjdk7/ http://ftp.us.debian.org/debian/pool/main/o/openjdk-7/openjdk-7-jdk_7u161-2.6.12-1_REPLACE_ARCH3.deb
-RUN cd /home/REPLACE_USERNAME/openjdk7/; dpkg -i *.deb; sudo apt --fix-broken -y install
+RUN apt-get update; apt install -y openjdk-8-jre:REPLACE_ARCH3 openjdk-8-jre-headless:REPLACE_ARCH3 openjdk-8-jdk:REPLACE_ARCH3
+RUN sudo apt --fix-broken -y install
 # java-install-pm
 
 # hadoop-install-man
-RUN wget -N -q -P /home/REPLACE_USERNAME https://archive.apache.org/dist/hadoop/common/hadoop-2.6.1/hadoop-2.6.1.tar.gz
+RUN wget -N -q -P /home/REPLACE_USERNAME https://archive.apache.org/dist/hadoop/common/hadoop-2.7.5/hadoop-2.7.5.tar.gz
 RUN /bin/true; cd /home/REPLACE_USERNAME; sudo tar -xzf /home/REPLACE_USERNAME/hadoop*.gz
 # hadoop-install-man
 

--- a/docker/workload/Dockerfile-ubuntu_cb_ycsb
+++ b/docker/workload/Dockerfile-ubuntu_cb_ycsb
@@ -1,21 +1,18 @@
 FROM REPLACE_NULLWORKLOAD_UBUNTU
 
 # java-install-pm
-RUN apt-get update; mkdir /home/REPLACE_USERNAME/openjdk7/ ; wget -N -q -P /home/REPLACE_USERNAME/openjdk7/ http://ftp.us.debian.org/debian/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_1.5.2-2+b1_REPLACE_ARCH3.deb
-RUN wget -N -q -P /home/REPLACE_USERNAME/openjdk7/ http://ftp.us.debian.org/debian/pool/main/o/openjdk-7/openjdk-7-jre-headless_7u161-2.6.12-1_REPLACE_ARCH3.deb
-RUN wget -N -q -P /home/REPLACE_USERNAME/openjdk7/ http://ftp.us.debian.org/debian/pool/main/o/openjdk-7/openjdk-7-jre_7u161-2.6.12-1_REPLACE_ARCH3.deb
-RUN wget -N -q -P /home/REPLACE_USERNAME/openjdk7/ http://ftp.us.debian.org/debian/pool/main/o/openjdk-7/openjdk-7-jdk_7u161-2.6.12-1_REPLACE_ARCH3.deb
-RUN cd /home/REPLACE_USERNAME/openjdk7/; dpkg -i *.deb; sudo apt --fix-broken -y install
+RUN apt-get update; apt install -y openjdk-8-jre:REPLACE_ARCH3 openjdk-8-jre-headless:REPLACE_ARCH3 openjdk-8-jdk:REPLACE_ARCH3
+RUN sudo apt --fix-broken -y install
 # java-install-pm
 
 # cassandra-install-man
 RUN wget -N -q -P /home/REPLACE_USERNAME http://launchpadlibrarian.net/109052632/python-support_1.0.15_all.deb; dpkg -i /home/REPLACE_USERNAME/python-support*.deb; sudo apt --fix-broken -y install
-RUN wget -N -q -P /home/REPLACE_USERNAME http://dl.bintray.com/apache/cassandra/pool/main/c/cassandra/cassandra_2.1.1_all.deb
+RUN wget -N -q -P /home/REPLACE_USERNAME http://dl.bintray.com/apache/cassandra/pool/main/c/cassandra/cassandra_2.1.20_all.deb 
 RUN dpkg -i /home/REPLACE_USERNAME/cassandra*.deb; sudo apt --fix-broken -y install
 # cassandra-install-man
 
 # cassandra-tools-install-man
-RUN wget -N -q -P /home/REPLACE_USERNAME http://dl.bintray.com/apache/cassandra/pool/main/c/cassandra/cassandra-tools_2.1.1_all.deb
+RUN wget -N -q -P /home/REPLACE_USERNAME http://dl.bintray.com/apache/cassandra/pool/main/c/cassandra/cassandra-tools_2.1.20_all.deb 
 RUN dpkg -i /home/REPLACE_USERNAME/cassandra-tools*.deb; sudo apt --fix-broken -y install
 # service_stop_disable cassandra
 # cassandra-tools-install-man

--- a/scripts/cassandra_ycsb/virtual_application.txt
+++ b/scripts/cassandra_ycsb/virtual_application.txt
@@ -50,7 +50,7 @@ START=cb_run_ycsb.sh
 
 # VApp-specific OPTIONAL modifier parameters. Commented attributes imply default values assumed
 JAVA_HOME = auto
-JAVA_VER = 7
+JAVA_VER = 8
 JVM_STACK_SIZE = 1024k
 READ_RATIO = workloaddefault
 UPDATE_RATIO = workloaddefault

--- a/scripts/hadoop/virtual_application.txt
+++ b/scripts/hadoop/virtual_application.txt
@@ -48,7 +48,7 @@ START = cb_run_hadoop.sh
 
 # VApp-specific modifier parameters.
 JAVA_HOME = auto
-JAVA_VER = 7
+JAVA_VER = 8
 HADOOP_HOME = ~/hadoop-2.6.1
 HADOOP_EXAMPLES = share/hadoop/mapreduce/hadoop-mapreduce-examples-VERSION.jar
 HIBENCH_HOME = ~/HiBench


### PR DESCRIPTION
docker: cassandra => 2.1.20, hadoop => 2.7.5, openjdk => 8

The docker container software didn't match what's currently
in the latest SPEC Cloud documention.