### PR TITLE
Improvements and bugfixes in common bash functions

### DIFF
--- a/scripts/common/cb_common.py
+++ b/scripts/common/cb_common.py
@@ -546,7 +546,10 @@ def is_number(val) :
     '''
     try:
         _val = float(val)
-        return _val
+        if _val == 0.0 :
+            return True
+        else :
+            return _val
     
     except ValueError:
         return False

--- a/scripts/common/cb_common.sh
+++ b/scripts/common/cb_common.sh
@@ -1965,7 +1965,7 @@ function haproxy_setup {
         sudo openssl genrsa -out mydomain.key 2048
         sudo openssl req -new -key mydomain.key -out mydomain.csr -batch -verbose
         sudo openssl x509 -req -days 365 -in mydomain.csr -signkey mydomain.key -out mydomain.crt
-        sudo bash -c "cat mydomain.key mydomain.crt >> /etc/ssl/private/mydomain.pem
+        sudo bash -c "cat mydomain.key mydomain.crt >> /etc/ssl/private/mydomain.pem"
     fi
 
     f=/tmp/haporxy.cfg

--- a/scripts/common/cb_post_boot.sh
+++ b/scripts/common/cb_post_boot.sh
@@ -55,7 +55,7 @@ then
     syslog_netcat "Starting (AI) Object store..."
     start_redis ${osportnumber}
     syslog_netcat "Local (AI) Object store started"
-	setup_rclocal_restarts
+    setup_rclocal_restarts
 fi
 
 refresh_hosts_file

--- a/scripts/common/cb_report_app_metrics.py
+++ b/scripts/common/cb_report_app_metrics.py
@@ -35,7 +35,7 @@ for _arg in argv :
     elif _arg.count("force_conversion_") :
         _force_conversion = _arg.replace("force_conversion_",'')
     else :
-        if _arg.count(":") == 2 :                                                                                                 
+        if _arg.count(":") == 2 :
             _metric_list += _arg + ' '                                                                                    
 
 report_app_metrics(_metric_list, _sla_target_list, force_conversion = _force_conversion)


### PR DESCRIPTION
- When an user specifies, in the AI-specific <ROLE>_DATA_DIR attribute
the value "none" (indicating that a given application will use the volume without a filesystem on it), the function mount_filesystem_on_volume can now be called without resulting in error
- The function check_container now correctly detects the number of CPUs and amount of memory available, in KB.
- Make sure every other function (e.g., haproxy_setup) uses the function check_container