### PR TITLE
New Application Instance type, based on the stress-ng workload

### DIFF
--- a/scripts/stress/cb_check_stress.sh
+++ b/scripts/stress/cb_check_stress.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+#/*******************************************************************************
+# Copyright (c) 2012 IBM Corp.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/*******************************************************************************
+
+source ~/.bashrc
+
+source $(echo $0 | sed -e "s/\(.*\/\)*.*/\1.\//g")/cb_common.sh
+
+START=$(provision_application_start)
+
+SHORT_HOSTNAME=$(uname -n| cut -d "." -f 1)
+
+which stress-ng
+if [ $? -gt 0 ] ; then
+    syslog_netcat "stress-ng not installed on ${SHORT_HOSTNAME} - NOK"
+    exit 2
+else
+    syslog_netcat "stress-ng installed on ${SHORT_HOSTNAME} - OK"
+    provision_application_stop $START
+fi
+
+provision_application_stop $START

--- a/scripts/stress/cb_run_stress.sh
+++ b/scripts/stress/cb_run_stress.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+#/*******************************************************************************
+# Copyright (c) 2012 IBM Corp.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/*******************************************************************************
+
+source $(echo $0 | sed -e "s/\(.*\/\)*.*/\1.\//g")/cb_common.sh
+
+set_load_gen $@
+   
+
+CMDLINE="stress-ng --cpu ${LOAD_LEVEL}--cpu-method ${LOAD_PROFILE} --metrics-brief --perf -t ${LOAD_DURATION}"
+
+execute_load_generator "${CMDLINE}" ${RUN_OUTPUT_FILE} ${LOAD_DURATION}
+
+tp=$(cat ${RUN_OUTPUT_FILE} | grep cpu[[:space:]] | awk '{ print $10 }')
+
+~/cb_report_app_metrics.py \
+throughput:$tp:tps \
+$(common_metrics)    
+
+unset_load_gen
+
+exit 0

--- a/scripts/stress/dependencies.txt
+++ b/scripts/stress/dependencies.txt
@@ -1,0 +1,27 @@
+### START - Dependency installation order ###
+stress-order = 94
+### END - Dependency installation order ###
+
+### START - Dependency-specific installation method ###
+# pm = "package manager" (yum or apt-get)
+# sl = "soft link" (assume that the dependency is already installed, just has to
+# be properly exposed to the user's path.
+# git = git clone using above giturl
+# pip = python pip utility
+# man = "manual"
+stress-install = pm
+### END - Dependency-specific installation method ###
+
+### START - Tests ###
+stress-configure = stress-ng -V 2>&1 | cut -d ' ' -f 3
+### END - Tests ###
+
+### START - Dependency versions ###
+stress-ver = 0.08
+### END - Dependency versions ###
+
+### START -  Dependency and method-specific command lines ###
+
+# AUTOMATICALLY EXTRACTED FROM DOCKERFILE ON ../../docker/workload/
+
+### END -  Dependency and method-specific command lines ###

--- a/scripts/stress/virtual_application.txt
+++ b/scripts/stress/virtual_application.txt
@@ -1,0 +1,40 @@
+# Parameters for this Virtual Application (Application Instance - AI) type should
+# be set on YOUR private configuration configuration file, including the ones 
+# commented.
+
+[AI_TEMPLATES : STRESS]
+
+# Attributes MANDATORY for all Virtual Applications
+SUT = stress
+LOAD_BALANCER_SUPPORTED = $False
+RESIZE_SUPPORTED = $False
+REGENERATE_DATA = $False
+LOAD_GENERATOR_ROLE = stress
+LOAD_MANAGER_ROLE = stress
+METRIC_AGGREGATOR_ROLE = stress
+CAPTURE_ROLE = stres
+LOAD_PROFILE = matrixprod
+LOAD_LEVEL = uniformIXIXI1I5
+LOAD_DURATION = uniformIXIXI10I30
+CATEGORY = synthetic
+PROFILES = all,ackermann,bitops,callfunc,cdouble,cfloat,clongdouble,correlate,crc16,decimal32,decimal64,decimal128,dither,djb2a,double,euler,explog,fft,factorial,fibonacci,float,float32,float80,float128,fnv1a,gamma,gcd,gray,hamming,hanoi,hyperbolic,idct,int128,int64,int32,int16,int8,int128float,int128double,int128longdouble,int128decimal32,int128decimal64,int128decimal128,int64float,int64double,int64longdouble,int32float,int32double,int32longdouble,jenkin,jmp,ln2,longdouble,loop,matrixprod,nsqrt,omega,parity,phi,pi,pjw,prime,psi,queens,rand,rand48,rgb,sdbm,sieve,stats,sqrt,trig,union,zeta
+REFERENCE = https://kernel.ubuntu.com/~cking/stress-ng/
+LICENSE = GPL_v2
+REPORTED_METRICS = throughput,completion_time,quiescent_time,errors
+
+# VApp-specific MANDATORY attributes
+DESCRIPTION =Deploys a single instance an run the stress-ng\n
+DESCRIPTION +=benchmark, focusing on CPU-specific stress tests\n
+DESCRIPTION +=  - LOAD_PROFILE possible values: _PROFILES_.\n
+DESCRIPTION +=  - LOAD_LEVEL meaning: number "stressor" threads.\n 
+DESCRIPTION +=  - LOAD_DURATION meaning: maximum length of time to run.\n
+STRESS_SETUP1 = cb_check_stress.sh
+START = cb_run_stress.sh
+
+# VApp-specific modifier parameters.
+
+# Inter-Virtual Application instances (inter-AI) synchronized execution. Entirely optional
+#SYNC_COUNTER_NAME = synchronization_counter
+#CONCURRENT_AIS = 2
+#SYNC_CHANNEL_NAME = synchronization_channel
+#RUN_COUNTER_NAME = experiment_id_counter


### PR DESCRIPTION
- The only other CPU-intensive sythetic workload in CB - coremark -
requires a manual download from an EEBMC url. The package `stress-ng` is
available in Ubuntu/RHEL repos readily.