### PR TITLE
New Application Instance type: SLURM

### DIFF
--- a/scripts/slurm/cb_config_slurm_cluster.sh
+++ b/scripts/slurm/cb_config_slurm_cluster.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+#/*******************************************************************************
+# Copyright (c) 2019 IBM Corp.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/*******************************************************************************
+
+source $(echo $0 | sed -e "s/\(.*\/\)*.*/\1.\//g")/cb_common.sh
+
+START=`provision_application_start`
+
+SLURM_CONFIG_SOURCE_DIR=~/ubuntu-slurm
+eval SLURM_CONFIG_SOURCE_DIR=${SLURM_CONFIG_SOURCE_DIR}
+
+SLURM_CPU_PER_NODE=$(get_my_ai_attribute_with_default slurm_cpu_per_node 2)
+SLURM_MEMORY_PER_NODE=$(get_my_ai_attribute_with_default slurm_memory_per_node 3072)
+SLURM_DISK_PER_NODE=$(get_my_ai_attribute_with_default slurm_disk_per_node 8192)
+    
+sudo ln -s /etc/slurm-llnl /etc/slurm
+sudo ln -s /usr/lib/x86_64-linux-gnu/slurm-wlm /usr/lib/slurm
+
+sudo mkdir -p /etc/slurm/prolog.d /etc/slurm/epilog.d /var/spool/slurm/ctld /var/spool/slurmd /var/spool/slurm/d /var/log/slurm         
+
+sudo cp $SLURM_CONFIG_SOURCE_DIR/slurm.conf /etc/slurm/
+
+sudo cp $SLURM_CONFIG_SOURCE_DIR/slurmdbd.conf /etc/slurm/
+
+sudo chown slurm:slurm /etc/slurm /var/spool/slurm/ctld /var/spool/slurmd /var/spool/slurm/d /var/log/slurm
+
+sudo sed -i 's/^#.*OPTIONS=/OPTIONS=/g' /etc/default/munge
+sudo sed -i 's^PidFile=.*^PidFile=/var/run/slurm-llnl/slurmdbd.pid^g' /etc/slurm/slurmdbd.conf
+
+sudo sed -i 's^SlurmctldPidFile=.*^SlurmctldPidFile=/var/run/slurm-llnl/slurmctld.pid^g' /etc/slurm/slurm.conf
+sudo sed -i 's^SlurmdPidFile=.*^SlurmdPidFile=/var/run/slurm-llnl/slurmd.pid^g' /etc/slurm/slurm.conf
+
+sudo sed -i 's^SlurmctldLogFile=.*^SlurmctldLogFile=/var/log/slurm/slurmctld.log^g' /etc/slurm/slurm.conf
+sudo sed -i 's^SlurmdLogFile=.*^SlurmdLogFile=/var/log/slurm/slurmd.log^g' /etc/slurm/slurm.conf
+
+sudo ln -s /usr/lib/x86_64-linux-gnu/slurm-wlm /usr/lib/slurm
+sudo ln -s /lib/x86_64-linux-gnu/libpthread.so.0 /usr/lib/x86_64-linux-gnu/slurm-wlm/libpthread.so.0
+sudo ln -s /lib/x86_64-linux-gnu/libc.so.6 /usr/lib/x86_64-linux-gnu/slurm-wlm/libc.so.6
+
+sudo bash -c "echo -n \"${my_ai_name}\" | sha512sum | cut -d' ' -f1 >/etc/munge/munge.key"
+
+SERVICES[1]="mysql"
+SERVICES[2]="mysqld"
+
+linux_distribution
+
+if [[ ${my_role} == "slurmcontroller" ]]
+then
+    sudo mysql -u root < ~/mariadb_list_database.sql | grep slurm_acct_db  >/dev/null 2>&1        
+    if [[ $? -ne 0 ]]
+    then
+        service_restart_enable ${SERVICES[${LINUX_DISTRO}]}        
+        syslog_netcat "Creating slurmdb on MySQL server running on ${SHORT_HOSTNAME}" 
+        sudo mysql -u root < ~/mariadb_create_database.sql
+        if [[ $? -eq 0 ]]
+        then
+            syslog_netcat "slurmdb successfully created on MySQL server running on ${SHORT_HOSTNAME}" 
+        fi
+    fi
+fi
+
+syslog_netcat "Updating \"slurm.conf\"..."
+sudo sed -i "s/ClusterName=.*/ClusterName=$my_ai_name/g" /etc/slurm/slurm.conf
+sudo sed -i "s/ControlMachine=.*/ControlMachine=$(get_hostnames_from_role slurmcontroller)/g" /etc/slurm/slurm.conf
+sudo sed -i '/GresTypes=gpu/d' /etc/slurm/slurm.conf
+sudo sed -i '/DefMemPerNode=64000/d' /etc/slurm/slurm.conf    
+sudo sed -i '/NodeName=linux1 Gres=gpu:8 CPUs=80 Sockets=2 CoresPerSocket=20 ThreadsPerCore=2 RealMemory=515896 State=UNKNOWN/d' /etc/slurm/slurm.conf
+sudo sed -i '/PartitionName=debug Nodes=ALL Default=YES MaxTime=INFINITE State=UP/d' /etc/slurm/slurm.conf
+sudo bash -c "echo \"PartitionName=${my_ai_name}p1 Nodes=ALL Default=YES MaxTime=INFINITE State=UP\" >> /etc/slurm/slurm.conf"
+for cn in $(get_hostnames_from_role slurmcompute)
+do
+    sudo bash -c "echo \"Nodename=$cn CPUs=$SLURM_CPU_PER_NODE RealMemory=$SLURM_MEMORY_PER_NODE TmpDisk=$SLURM_DISK_PER_NODE\" >> /etc/slurm/slurm.conf"
+done
+
+sudo bash -c "echo \"CgroupAutomount=yes\" > /etc/slurm/cgroup.conf"
+sudo bash -c "echo \"ConstrainCores=yes\" >> /etc/slurm/cgroup.conf"
+
+exit 0

--- a/scripts/slurm/cb_run_slurm_cluster.sh
+++ b/scripts/slurm/cb_run_slurm_cluster.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+source $(echo $0 | sed -e "s/\(.*\/\)*.*/\1.\//g")/cb_common.sh
+
+set_load_gen $@
+
+cd ~
+
+CMDLINE="sleep 600"
+
+execute_load_generator "${CMDLINE}" ${RUN_OUTPUT_FILE} ${LOAD_DURATION}
+
+tp=$(cat ${RUN_OUTPUT_FILE} | grep QPS | awk '{ print $2 }')
+lat=$(cat ${RUN_OUTPUT_FILE} | grep avg | sed 's/avg: //g' | tr -d ' ')
+lat_95=$( cat ${RUN_OUTPUT_FILE} | grep 95p | sed 's/95p: //g' | tr -d ' ')
+
+~/cb_report_app_metrics.py \
+datagen_time:$(update_app_datagentime):sec \
+datagen_size:$(update_app_datagensize):records \
+throughput:$tp:tps \
+$(format_for_report latency $lat) \
+$(format_for_report 95_latency $lat_95) \
+$(common_metrics)
+ 
+unset_load_gen
+
+exit 0

--- a/scripts/slurm/cb_start_slurm_cluster.sh
+++ b/scripts/slurm/cb_start_slurm_cluster.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+#/*******************************************************************************
+# Copyright (c) 2019 IBM Corp.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/*******************************************************************************
+
+source $(echo $0 | sed -e "s/\(.*\/\)*.*/\1.\//g")/cb_common.sh
+
+service_restart_enable munge 
+
+munge -n >/dev/null 2>&1 
+if [[ $? -ne 0 ]]
+then 
+    syslog_netcat "Munge configuration successfully checked on ${SHORT_HOSTNAME}"
+else
+    syslog_netcat "Munge configuration checking failure on ${SHORT_HOSTNAME}"
+fi
+
+if [[ ${my_role} == "slurmcontroller" ]]
+then
+    service_restart_enable slurmdbd
+
+    service_restart_enable slurmctld
+
+#    sudo sacctmgr add cluster $my_ai_name -i
+#    sudo sacctmgr add account compute-account description="Compute accounts" Organization=OurOrg -i
+#    sudo sacctmgr create user $(whoami) account=compute-account adminlevel=None -i
+else
+    wait_until_port_open $(get_ips_from_role slurmcontroller) 6817 20 5
+    service_restart_enable slurmd
+fi
+
+provision_application_stop
+
+exit 0

--- a/scripts/slurm/dependencies.txt
+++ b/scripts/slurm/dependencies.txt
@@ -1,0 +1,43 @@
+### START - Dependency installation order ###
+slurm-components-order = 85
+munge-order = 86
+mariadb-order = 87
+slurm-order = 88
+### END - Dependency installation order ###
+
+### START - Dependency-specific installation method ###
+# pm = "package manager" (yum or apt-get)
+# sl = "soft link" (assume that the dependency is already installed, just has to
+# be properly exposed to the user's path.
+# git = git clone using above giturl
+# pip = python pip utility
+# man = "manual"
+slurm-components-install = man
+munge-install = pm
+mariadb-install = pm
+slurm-install = pm
+### END - Dependency-specific installation method ###
+
+### START - Tests ###
+slurm-components-configure = ls /home/REPLACE_USERNAME/ubuntu-slurm/
+munge-configure = munge -V | cut -d ' ' -f 1 | sed 's/munge-//g'
+mariadb-configure = mysql --version | cut -d ' ' -f 4
+slurm-configure = sudo dpkg -l | grep slurm | cut -d ' ' -f 3 | sed 's/slurm-//g'
+### END - Tests ###
+
+### START - Dependency versions ###
+slurm-components-ver = ANY
+munge-ver = 0.4
+mariadb-ver = 10
+slurm-ver = 16
+### END - Dependency versions ###
+
+### START - Dependency URLs ###
+
+### END - Dependency URLs ###
+
+### START -  Dependency and method-specific command lines ###
+
+# AUTOMATICALLY EXTRACTED FROM DOCKERFILE ON ../../docker/workload/
+
+### END -  Dependency and method-specific command lines ###

--- a/scripts/slurm/mariadb_create_database.sql
+++ b/scripts/slurm/mariadb_create_database.sql
@@ -1,0 +1,7 @@
+create database slurm_acct_db;
+create user 'slurm'@'localhost';
+set password for 'slurm'@'localhost' = password('slurmdbpass');
+grant usage on *.* to 'slurm'@'localhost';
+grant all privileges on slurm_acct_db.* to 'slurm'@'localhost';
+flush privileges;
+exit

--- a/scripts/slurm/mariadb_list_database.sql
+++ b/scripts/slurm/mariadb_list_database.sql
@@ -1,0 +1,2 @@
+show databases;
+exit

--- a/scripts/slurm/virtual_application.txt
+++ b/scripts/slurm/virtual_application.txt
@@ -1,0 +1,48 @@
+# Parameters for this Virtual Application (Application Instance - AI) type should
+# be set on YOUR private configuration configuration file, including the ones 
+# commented.
+
+[AI_TEMPLATES : SLURM] 
+
+# Attributes MANDATORY for all Virtual Applications
+SUT = slurmcontroller->2_x_slurmcompute
+LOAD_BALANCER_SUPPORTED = $False
+RESIZE_SUPPORTED = $False
+REGENERATE_DATA = $False 
+LOAD_GENERATOR_ROLE = slurmcontroller
+LOAD_MANAGER_ROLE = slurmcontroller
+METRIC_AGGREGATOR_ROLE = slurmcontroller
+CAPTURE_ROLE = slurmcontroller
+LOAD_PROFILE = default
+LOAD_LEVEL = uniformIXIXI1I2
+LOAD_DURATION = 60
+CATEGORY = scientific
+PROFILES = default
+REFERENCE = https://slurm.schedmd.com/
+LICENSE = Public_Domain
+REPORTED_METRICS = completion_time,errors,quiescent_time
+
+# VApp-specific MANDATORY attributes
+DESCRIPTION =Deploys a Slurm cluster (1 controller instance and N compute instances).\n
+DESCRIPTION +=The master node also runs the "XXXX" benchmark, which is used\n
+DESCRIPTION +=to submit spark jobs to the cluster.\n
+DESCRIPTION +=  - LOAD_PROFILE possible values: TBD1 (tbd tbd tbd), \n
+DESCRIPTION +=    and TBD2 (tbd tbd tbd)\n
+DESCRIPTION +=  - LOAD_LEVEL meaning: although the specifics vary by load profile,\n
+DESCRIPTION +=    it basically represents "amount of data" generated and processed\n
+DESCRIPTION +=    by the job.\n 
+DESCRIPTION +=  - LOAD_DURATION meaning: not used, a run ends when the slurm job\n
+DESCRIPTION +=    is completed.\n
+SLURMCONTROLLER_SETUP1 = cb_config_slurm_cluster.sh
+SLURMCOMPUTE_SETUP1 = cb_config_slurm_cluster.sh
+SLURMCONTROLLER_SETUP2 = cb_start_slurm_cluster.sh
+SLURMCOMPUTE_SETUP2 = cb_start_slurm_cluster.sh
+START = cb_run_slurm.sh
+
+# VApp-specific modifier parameters. Commented attributes imply default values assumed
+
+# Inter-Virtual Application instances (inter-AI) synchronized execution. Entirely optional
+#SYNC_COUNTER_NAME = synchronization_counter
+#CONCURRENT_AIS = 2
+#SYNC_CHANNEL_NAME = synchronization_channel
+#RUN_COUNTER_NAME = experiment_id_counter


### PR DESCRIPTION
- SLURM is a free and open-source job scheduler for Linux and Unix-like
kernels, used mostly in HPC environments.
- This initial implementation in CB takes care of creating the Slurm
cluster and making sure all the nodes join properly. In a future
expansion, will add support for running multiple applicatons (load
generating processes) via Slurm.