### PR TITLE
broken readline history file function

### DIFF
--- a/cb
+++ b/cb
@@ -142,6 +142,12 @@ def main() :
                 break
             except KeyboardInterrupt :
                 print ("CTRL-D or quit to exit")
-    readline.write_history_file(os.path.expanduser("~") + "/.cb_history")
+    readline.write_history_file(_history + ".tmp")
+    _history_fh = open(_history + ".tmp")
+    _history_contents = _history_fh.read()
+    _history_fh.close()
+    _history_fh = open(_history, 'w')
+    _history_fh.write(_history_contents)
+    _history_fh.close()
     
 main()


### PR DESCRIPTION
In newer versions of python 2.7 (presumably v3 as well) when
combined with Ubuntu 18.04, the `readline.write_history_file` function
has changed to actually use the `rename` system call instead of
updating the history in place.

This causes problems in Docker-based environments, because we attempt
to preserve the CB history file by including it via `docker -v` as
a bind mount. Since python is unable to replace the file (Because
the container doesn't own it), this fails.

The solution is to use a temporary file and move the contents of the
temporary file to the bind-mounted file.

This solution should work with and without docker as well and be transparent.