### PR TITLE
fix for when nested container SSH loses connectivity

### DIFF
--- a/scripts/common/cb_common.sh
+++ b/scripts/common/cb_common.sh
@@ -1354,6 +1354,11 @@ function replicate_to_container_if_nested {
         return 1
     fi
 
+    if [ -e /.dockerenv ] ; then
+        syslog_netcat "The container did startup. Continuing to use it..."
+        return 1
+    fi
+
     nest_containers_enabled=`get_my_vm_attribute nest_containers_enabled`
 
     if [ x"${nest_containers_enabled}" != x"True" ] ; then


### PR DESCRIPTION
If connectivity is lost in the middle of the boostrapping the container,
we can sometimes get into a state were the container actually did startup
but we didn't realize it. So we need to doubly-check whether or not
we're actually running inside a container.