### PR TITLE
Public-network haproxy

### DIFF
--- a/configs/templates/internal_options.txt
+++ b/configs/templates/internal_options.txt
@@ -275,6 +275,10 @@ PAUSE_AFTER_RUN = $False
 # This allows the tester to prevent the load manager from doing anything
 # upon initial startup
 PAUSE_AFTER_ATTACHED = $False
+# It's common for a load balancer to accept traffic from the internet but
+# balance it on the private network. Let's support that.
+# By default, we assume all LB traffic stays on the private network.
+USE_PUBLIC_LB_NETWORK=$False
 
 [AIDRS_DEFAULTS]
 USERNAME = $MAIN_USERNAME

--- a/lib/clouds/ec2_cloud_ops.py
+++ b/lib/clouds/ec2_cloud_ops.py
@@ -440,6 +440,8 @@ class Ec2Cmds(CommonCloudFunctions) :
             _private_ip_address = '{0}'.format(obj_attr_list["instance_obj"].private_ip_address)
             _public_hostname = '{0}'.format(obj_attr_list["instance_obj"].public_dns_name)
             _public_hostname, _public_ip_address = hostname2ip(_public_hostname)
+            obj_attr_list["public_cloud_ip"] = _public_ip_address
+
             if obj_attr_list["run_netname"] == "private" :
                 obj_attr_list["cloud_hostname"] = _private_hostname
                 obj_attr_list["run_cloud_ip"] = _private_ip_address

--- a/lib/clouds/gce_cloud_ops.py
+++ b/lib/clouds/gce_cloud_ops.py
@@ -498,6 +498,7 @@ class GceCmds(CommonCloudFunctions) :
                        
             _public_hostname = obj_attr_list["cloud_vm_name"] + '.' + obj_attr_list["vmc_name"]
             _private_hostname = obj_attr_list["cloud_vm_name"] + '.' + obj_attr_list["vmc_name"]
+            obj_attr_list["public_cloud_ip"] = _public_ip_address
                         
             if obj_attr_list["run_netname"] == "private" :
                 obj_attr_list["cloud_hostname"] = _private_hostname

--- a/lib/clouds/kub_cloud_ops.py
+++ b/lib/clouds/kub_cloud_ops.py
@@ -593,6 +593,7 @@ class KubCmds(CommonCloudFunctions) :
                     service.reload()
                     if "loadBalancer" in service.obj["status"] and "ingress" in service.obj["status"]["loadBalancer"] :
                         obj_attr_list["prov_cloud_ip"] = service.obj["status"]["loadBalancer"]["ingress"][0]["ip"]
+                        obj_attr_list["public_cloud_ip"] = service.obj["status"]["loadBalancer"]["ingress"][0]["ip"]
                         # NOTE: "cloud_ip" is always equal to "run_cloud_ip"
                         cbdebug("Found external IP: " + obj_attr_list["prov_cloud_ip"], True)
                     else :

--- a/lib/clouds/libcloud_common.py
+++ b/lib/clouds/libcloud_common.py
@@ -844,6 +844,9 @@ class LibcloudCmds(CommonCloudFunctions) :
             _msg += " Private IP = " + str(node.private_ips)
             cbdebug(_msg)
 
+            if len(node.public_ips) > 0 :
+                obj_attr_list["public_cloud_ip"] = node.public_ips[0]
+
             if len(node.private_ips) > 0 :
                 if obj_attr_list["prov_netname"].lower() == "private" :
                     obj_attr_list["prov_cloud_ip"] = node.private_ips[0]

--- a/lib/clouds/slr_cloud_ops.py
+++ b/lib/clouds/slr_cloud_ops.py
@@ -451,6 +451,9 @@ class SlrCmds(CommonCloudFunctions) :
         elif obj_attr_list["prov_netname"] == "public" :
             _key = ''
 
+        if ("primaryIpAddress" in instance) :
+            obj_attr_list["public_cloud_ip"] = instance["primaryIpAddress"]
+
         if ("primary" + _key + "IpAddress") in instance :
             obj_attr_list["prov_cloud_ip"] = instance["primary" + _key + "IpAddress"]
             obj_attr_list["run_cloud_ip"] = instance["primary" + _key + "IpAddress"]

--- a/lib/operations/base_operations.py
+++ b/lib/operations/base_operations.py
@@ -2411,7 +2411,10 @@ class BaseObjectOperations :
                                                                  False)
 
                             obj_attr_list["load_generator_target_vm"] += _vm_uuid + ','
-                            obj_attr_list["load_generator_target_ip"] += _vm_attr_list["run_cloud_ip"] + ','
+                            if str(obj_attr_list["use_public_lb_network"]).lower() == "true" :
+                                obj_attr_list["load_generator_target_ip"] += _vm_attr_list["public_cloud_ip"] + ','
+                            else :
+                                obj_attr_list["load_generator_target_ip"] += _vm_attr_list["run_cloud_ip"] + ','
 
                     obj_attr_list["load_generator_target_vm"] = obj_attr_list["load_generator_target_vm"][:-1]
                     obj_attr_list["load_generator_target_ip"] = obj_attr_list["load_generator_target_ip"][:-1]


### PR DESCRIPTION
In public clouds, it's quite common for the load balancer to receive
traffic from the internet but actually load balance to the private network,
causing both virtual interfaces to experience load.

Let's support that.