### PR TITLE
Pause on offline droplets

### DIFF
--- a/scripts/common/cb_common.sh
+++ b/scripts/common/cb_common.sh
@@ -108,7 +108,7 @@ function check_container {
 
     # If we're using nesting (workload container inside a VM),
     # we still want to mount external volumes in the container.
-    if [[ $(sudo cat /proc/1/cgroup | grep -c docker) -ne 0 ]] && [[ x"${nest_containers_enabled}" != x"True" ]]
+    if [ -e /.dockerenv ] && [[ x"${nest_containers_enabled}" != x"True" ]]
     then
         export IS_CONTAINER=1
         if [[ -z $LC_ALL ]]


### PR DESCRIPTION
From time to time (for whatever reason) VMs can go offline during a benchmark.

In public clouds, this should be transparent by design. The user is not supposed
to "care" that VMs experienced transient issues like that from the perspective
of the API of the respective cloud provider.

If a hypervisor dies and causes a VM to go offline, while this obviously sucks,
CB should not simply "trust" that the cloud is going to bring the VM back online,
because this can cause our interpretation of benchmarks to be wrong.

Our policy (from the libcloud perspective) for public clouds during these error
condtions is zero tolerance: If at ANY time something bad happens during the process
of running a benchmark, we simply don't allow it.

Thus, during a reset of the benchmark, if a VM suddenly went offline, we notify the
user explicitly and require them to "manually" bring those VMs back online.

If and only if those VMs come back into an online state do we allow the cleanup
process to resume.