### PR TITLE
Add ability to automatically configure firewall on instances

### DIFF
--- a/configs/templates/internal_options.txt
+++ b/configs/templates/internal_options.txt
@@ -224,6 +224,7 @@ PREPARE_IMAGE_NAME = None
 NEST_CONTAINERS_ENABLED = $False
 NEST_CONTAINERS_REPOSITORY = ibmcb
 NEST_CONTAINERS_INSECURE_REGISTRY = $False
+CONFIGURE_FIREWALL = $False
 # Use the 'openssl' command to choose a password to enable this feature.
 # Requires cloud-init support.
 PASSWORD = $False # Disabled

--- a/configs/templates/internal_options.txt
+++ b/configs/templates/internal_options.txt
@@ -224,7 +224,7 @@ PREPARE_IMAGE_NAME = None
 NEST_CONTAINERS_ENABLED = $False
 NEST_CONTAINERS_REPOSITORY = ibmcb
 NEST_CONTAINERS_INSECURE_REGISTRY = $False
-CONFIGURE_FIREWALL = $False
+CONFIGURE_FIREWALL = $True
 # Use the 'openssl' command to choose a password to enable this feature.
 # Requires cloud-init support.
 PASSWORD = $False # Disabled

--- a/lib/operations/base_operations.py
+++ b/lib/operations/base_operations.py
@@ -1551,6 +1551,12 @@ class BaseObjectOperations :
         _log_store = self.osci.get_object(obj_attr_list["cloud_name"], \
                                              "GLOBAL", False, \
                                              "logstore", False)
+        
+        _api_attr_list = self.osci.get_object(obj_attr_list["cloud_name"], \
+                                                       "GLOBAL", \
+                                                       False, \
+                                                       "api_defaults", \
+                                                       False)
 
         obj_attr_list["filestore_host"] = _filestor_attr_list["hostname"]
         obj_attr_list["filestore_port"] = _filestor_attr_list["port"]
@@ -1577,6 +1583,12 @@ class BaseObjectOperations :
         obj_attr_list["objectstore_timeout"] = self.osci.timout
                 
         obj_attr_list["objectstore_protocol"] = "TCP"         
+
+        obj_attr_list["api_host"] = _api_attr_list["hostname"]
+        obj_attr_list["api_port"] = _api_attr_list["port"]
+
+        obj_attr_list["objectstore_dbid"] = self.osci.dbid
+        obj_attr_list["objectstore_timeout"] = self.osci.timout
 
         if obj_attr_list["login"] != "root" :
             obj_attr_list["remote_dir_home"] = "/home/" + obj_attr_list["login"]

--- a/scripts/common/cb_post_boot.sh
+++ b/scripts/common/cb_post_boot.sh
@@ -69,6 +69,12 @@ then
     sudo virsh net-undefine default >/dev/null 2>&1
 fi
 
+configure_firewall=$(get_my_vm_attribute configure_firewall)
+if [[ $(echo $configure_firewall | tr '[:upper:]' '[:lower:]') == "true" ]]
+then
+    configure_firewall
+fi
+
 post_boot_executed=`get_my_vm_attribute post_boot_executed`
 
 if [[ x"${post_boot_executed}" == x"true" ]]


### PR DESCRIPTION
By setting the attribute `CONFIGURE_FIREWALL` to `$True`, a new
`configure_firewall` function will be run during the "post-boot" phase
will make sure that instances can be accessed only by the Orchestrator
node and instances that are part of the same AI. The main use case for
it is public clouds where instances get a directly accessible public IP.
While an experimenter can (and should) configure the cloud-specific
controls for "virtual networking security groups", at an small cost in
terms of code, we can provide a cloud-agnostic solution that should
protect everything out of the box.