### PR TITLE
This commit greatly improves the debugging of the Load Manager.

### DIFF
--- a/lib/operations/base_operations.py
+++ b/lib/operations/base_operations.py
@@ -2728,8 +2728,15 @@ class BaseObjectOperations :
                             break
                         else :
                             if "dont_start_load_manager" in _ai_attr_list \
-                                and _ai_attr_list["dont_start_load_manager"].lower() == "true" :
-                                _lmr = True
+                            and _ai_attr_list["dont_start_load_manager"].lower() == "true" :
+                                _lmr = _ai_attr_list["load_manager_role"]
+                                
+                                _msg = "Adding the startup of the load manager, in \"debug mode\" only, to the "
+                                _msg += "list of commands. It will be executed on the "
+                                _msg += "VM with the role \"" + _lmr + "\""
+                                cbdebug(_msg)
+                                
+                                _ai_attr_list[_lmr + '_' + operation + str(_num + 1)] = "cb_start_load_manager.sh debug"
 
                             else :
                                 # This needs to be done only once, at the AI's


### PR DESCRIPTION
From now on, when `appnoload`/`dont_start_load_manager` is set, we
actually execute the load manager, but in "debug" mode. This means that
all load manager startup scripts are created on the correct instance(s),
but they are not actually executed. This change makes the current code
compatible with the updated documentation in
https://github.com/ibmcb/cbtool/wiki/HOWTO:-Debug-initial-setup, and
especially https://github.com/ibmcb/cbtool/wiki/FAQ-U#uq19.