### PR TITLE
Add the TPC-C workload

### DIFF
--- a/configs/templates/_do.txt
+++ b/configs/templates/_do.txt
@@ -164,5 +164,6 @@ XPINGSENDER =  size:512mb, imageid1:cb_xping
 YATINYVM = size:512mb, imageids:1, imageid1:cloudbench-nullworkload-on-1604.051818-1
 YCSB = size:4gb, imageids:1, imageid1:cloudbench-ycsb-cassandra-on-1604.051818-1
 NEST_CONTAINERS_BASE_IMAGE = size:NA, imageids:1, imageid1:18.04_x64, cloudinit_packages:openvpn;bc;jq;docker.io;python;redis-server
+TPCC = size:4gb, imageid1:not_important
 
 [CONTAINER_TEMPLATES]

--- a/configs/templates/_dok8s.txt
+++ b/configs/templates/_dok8s.txt
@@ -177,3 +177,4 @@ XPINGRECEIVER =  size:1-256, imageid1:cb_xping
 XPINGSENDER =  size:1-256, imageid1:cb_xping
 YATINYVM = size:1-256, imageid1:cb_nullworkload
 YCSB = size:2-4096, imageid1:cb_ycsb
+TPCC = size:2-4096, imageid1:cb_tpcc

--- a/configs/templates/internal_options.txt
+++ b/configs/templates/internal_options.txt
@@ -564,3 +564,4 @@ BONNIE = imageids:1, imageid1:ubuntu_cb_bonnie
 LINPACK = imageids:1, imageid1:ubuntu_cb_linpack
 KERNBENCH = imageids:1, imageid1:ubuntu_cb_kernbench
 LB = imageids:1, imageid1:ubuntu_cb_nullworkload
+TPCC = imageids:1, imageid1:ubuntu_cb_tpcc

--- a/docker/workload/Dockerfile-centos_cb_nullworkload
+++ b/docker/workload/Dockerfile-centos_cb_nullworkload
@@ -113,7 +113,7 @@ RUN ln -s $(sudo which rsyslogd) /usr/local/bin/rsyslogd
 # rsyslog-install-pm
 
 # apache-install-pm
-RUN yum____-y____install____httpd; /bin/true
+RUN yum -y install httpd; /bin/true
 # apache-install-pm
 
 # redis-install-pm

--- a/docker/workload/Dockerfile-ubuntu_cb_tpcc
+++ b/docker/workload/Dockerfile-ubuntu_cb_tpcc
@@ -1,0 +1,22 @@
+FROM REPLACE_NULLWORKLOAD_UBUNTU
+
+# redis-install-pip
+RUN pip install redis==2.10.6
+# redis-install-pip
+
+# mysql-install-pm
+RUN echo "mysql-server-5.7 mysql-server/root_password password temp4now" | sudo debconf-set-selections; echo "mysql-server-5.7 mysql-server/root_password_again password temp4now" | sudo debconf-set-selections
+RUN apt-get update
+RUN apt-get install -y mysql-server python-mysqldb python-pip python-dev libmysqlclient-dev
+# mysql-install-pm
+
+# sysbench-install-pm
+RUN apt-get install -y lsb-release
+RUN lsb_release -sc
+RUN wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+RUN sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+RUN apt-get update
+RUN apt-get install -y sysbench sysbench-tpcc
+# sysbench-install-pm
+
+RUN chown -R REPLACE_USERNAME:REPLACE_USERNAME /home/REPLACE_USERNAME

--- a/scripts/hpcc/cb_run_hpcc.sh
+++ b/scripts/hpcc/cb_run_hpcc.sh
@@ -95,7 +95,7 @@ sed -i s/"<NBs>"/"$NB_SIZE"/g      $infile
 sed -i s/"<Ps>"/"1"/g              $infile
 sed -i s/"<Qs>"/"$NUM_PROCESSES"/g $infile
 
-CMDLINE="mpirun -np $NUM_PROCESSES --machinefile $cluster_hosts_file --mca btl tcp,self $bench_app_bin"
+CMDLINE="mpirun --allow-run-as-root -np $NUM_PROCESSES --machinefile $cluster_hosts_file --mca btl tcp,self $bench_app_bin"
 
 execute_load_generator "${CMDLINE}" ${RUN_OUTPUT_FILE} ${LOAD_DURATION}
 

--- a/scripts/scimark/cb_run_scimark.sh
+++ b/scripts/scimark/cb_run_scimark.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 
 source $(echo $0 | sed -e "s/\(.*\/\)*.*/\1.\//g")/cb_common.sh
+SCIMARK_HOME=`get_my_ai_attribute_with_default scimark_home "~"`
 
 set_load_gen $@
 
 set_java_home
 
-cd ~
+cd ${SCIMARK_HOME}
 
-SCIMARK_DIR="~/jnt"
+SCIMARK_DIR="${SCIMARK_HOME}/jnt"
 eval SCIMARK_DIR=${SCIMARK_DIR}
 
 CBUSERLOGIN=`get_my_ai_attribute login`

--- a/scripts/tpcc/cb_reset_mysql.sh
+++ b/scripts/tpcc/cb_reset_mysql.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+#/*******************************************************************************
+# Copyright (c) 2012 IBM Corp.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/*******************************************************************************
+
+source ~/.bashrc
+source $(echo $0 | sed -e "s/\(.*\/\)*.*/\1.\//g")/cb_common.sh
+
+MYSQL_CONF_FILE=`get_my_ai_attribute_with_default mysql_conf_file /etc/mysql/mysql.conf.d/mysqld.cnf`
+MYSQL_RAM_PERCENTAGE=`get_my_ai_attribute_with_default mysql_ram_percentage 70`
+MYSQL_INNODB_IO_CAPACITY=`get_my_ai_attribute_with_default mysql_innodb_io_capacity 200`
+MYSQL_INNODB_LOG_FILE_SIZE=`get_my_ai_attribute_with_default mysql_innodb_log_file_size 48M`
+MYSQL_QUERY_CACHE_SIZE=`get_my_ai_attribute_with_default mysql_query_cache_size 16M`
+MYSQL_TMP_TABLE_SIZE=`get_my_ai_attribute_with_default mysql_tmp_table_size 16M`
+MYSQL_TABLE_OPEN_CACHE=`get_my_ai_attribute_with_default mysql_table_open_cache 2000`
+
+SUDO_CMD=`which sudo`
+
+RESTART_MYSQL=0
+
+update_mysql_setting()
+{
+	SETTING=$1
+	VALUE=$2
+
+	if grep "${SETTING} = ${VALUE}" ${MYSQL_CONF_FILE} >/dev/null; then
+		return
+	fi
+
+	syslog_netcat "Updating ${SETTING} to ${VALUE}"
+	${SUDO_CMD} sed -i 's/${SETTING}.*/${SETTING} = ${VALUE}' ${MYSQL_CONF_FILE}
+	RESTART_MYSQL=1
+}
+
+# Check if mysql has the right cache size or update it.
+kb=$(cat /proc/meminfo  | sed -e "s/ \+/ /g" | grep MemTotal | cut -d " " -f 2) 
+mb=$(echo "$kb / 1024 * ${MYSQL_RAM_PERCENTAGE} / 100" | bc)
+
+update_mysql_setting innodb_buffer_pool_size ${mb}M
+update_mysql_setting innodb_io_capacity ${MYSQL_INNODB_IO_CAPACITY}
+update_mysql_setting innodb_log_file_size ${MYSQL_INNODB_LOG_FILE_SIZE}
+update_mysql_setting query_cache_size ${MYSQL_QUERY_CACHE_SIZE}
+update_mysql_setting tmp_table_size ${MYSQL_TMP_TABLE_SIZE}
+update_mysql_setting table_open_cache ${MYSQL_TABLE_OPEN_CACHE}
+
+if test ${RESTART_MYSQL} = 1; then
+	service mysql restart
+	syslog_netcat "Restarting MySQL after setting update"
+fi

--- a/scripts/tpcc/cb_restart_mysql.sh
+++ b/scripts/tpcc/cb_restart_mysql.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+#/*******************************************************************************
+# Copyright (c) 2012 IBM Corp.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#/*******************************************************************************
+
+source ~/.bashrc
+source $(echo $0 | sed -e "s/\(.*\/\)*.*/\1.\//g")/cb_common.sh
+
+MYSQL_DATABASE_NAME=`get_my_ai_attribute_with_default mysql_database_name sysbenchdb`
+MYSQL_ROOT_PASSWORD=`get_my_ai_attribute_with_default mysql_root_password temp4now`
+MYSQL_NONROOT_USER=`get_my_ai_attribute_with_default mysql_nonroot_user sysbench`
+MYSQL_NONROOT_PASSWORD=`get_my_ai_attribute_with_default mysql_nonroot_password sysbench`
+MYSQL_DATA_DIR=`get_my_ai_attribute_with_default mysql_data_dir /sysbench`
+MYSQL_CONF_FILE=`get_my_ai_attribute_with_default mysql_conf_file /etc/mysql/mysql.conf.d/mysqld.cnf`
+MYSQL_RAM_PERCENTAGE=`get_my_ai_attribute_with_default mysql_ram_percentage 70`
+MYSQL_INNODB_IO_CAPACITY=`get_my_ai_attribute_with_default mysql_innodb_io_capacity 200`
+MYSQL_INNODB_LOG_FILE_SIZE=`get_my_ai_attribute_with_default mysql_innodb_log_file_size 48M`
+MYSQL_QUERY_CACHE_SIZE=`get_my_ai_attribute_with_default mysql_query_cache_size 16M`
+MYSQL_TMP_TABLE_SIZE=`get_my_ai_attribute_with_default mysql_tmp_table_size 16M`
+MYSQL_TABLE_OPEN_CACHE=`get_my_ai_attribute_with_default mysql_table_open_cache 2000`
+MYSQL_ENABLE_PMM_CLIENT=`get_my_ai_attribute_with_default mysql_enable_pmm_client False`
+MYSQL_PMM_SERVER=`get_my_ai_attribute_with_default mysql_pmm_server 0.0.0.0:80`
+
+SHORT_HOSTNAME=$(uname -n| cut -d "." -f 1)
+NETSTAT_CMD=`which netstat`
+SUDO_CMD=`which sudo`
+ATTEMPTS=3
+START=`provision_application_start`
+
+SERVICES[1]="mysql"
+SERVICES[2]="mysqld"
+
+if [[ ${MYSQL_DATA_DIR} != "/var/lib/mysql"  && ! -L /var/lib/mysql ]]
+then
+    syslog_netcat "Relocating MySQL base directory..."
+	service_stop_disable ${SERVICES[${LINUX_DISTRO}]}
+    ${SUDO_CMD} rsync -az --delete --inplace /var/lib/mysql/ ${MYSQL_DATA_DIR}/
+    ${SUDO_CMD} rm -rf /var/lib/mysql
+    ${SUDO_CMD} ln -s ${MYSQL_DATA_DIR} /var/lib/mysql        
+fi    
+
+${SUDO_CMD} sed -i "s^bind-address.*^bind-address            = $my_ip_addr^g" ${MYSQL_CONF_FILE}
+
+${SUDO_CMD} sed -i '/innodb_io_capacity/d' ${MYSQL_CONF_FILE}
+${SUDO_CMD} sed -i '/innodb_log_file_size/d' ${MYSQL_CONF_FILE}
+${SUDO_CMD} sed -i '/innodb_buffer_pool_size/d' ${MYSQL_CONF_FILE}
+${SUDO_CMD} sed -i '/query_cache_size/d' ${MYSQL_CONF_FILE}
+${SUDO_CMD} sed -i '/tmp_table_size/d' ${MYSQL_CONF_FILE}
+${SUDO_CMD} sed -i '/table_open_cache/d' ${MYSQL_CONF_FILE}
+${SUDO_CMD} sed -i '/innodb_buffer_pool_dump_at_shutdown/d' ${MYSQL_CONF_FILE}
+${SUDO_CMD} sed -i '/innodb_buffer_pool_load_at_startup/d' ${MYSQL_CONF_FILE}
+
+# Set mysql's memory cache size to be a percentage of main memory
+kb=$(cat /proc/meminfo  | sed -e "s/ \+/ /g" | grep MemTotal | cut -d " " -f 2)
+mb=$(echo "$kb / 1024 * ${MYSQL_RAM_PERCENTAGE} / 100" | bc)
+${SUDO_CMD} su -c "echo 'innodb_buffer_pool_size = ${mb}M' >> ${MYSQL_CONF_FILE}"
+
+${SUDO_CMD} su -c "echo 'innodb_io_capacity = ${MYSQL_INNODB_IO_CAPACITY}' >> ${MYSQL_CONF_FILE}"
+${SUDO_CMD} su -c "echo 'innodb_log_file_size = ${MYSQL_INNODB_LOG_FILE_SIZE}' >> ${MYSQL_CONF_FILE}"
+${SUDO_CMD} su -c "echo 'query_cache_size = ${MYSQL_QUERY_CACHE_SIZE}' >> ${MYSQL_CONF_FILE}"
+${SUDO_CMD} su -c "echo 'tmp_table_size = ${MYSQL_TMP_TABLE_SIZE}' >> ${MYSQL_CONF_FILE}"
+${SUDO_CMD} su -c "echo 'table_open_cache = ${MYSQL_TABLE_OPEN_CACHE}' >> ${MYSQL_CONF_FILE}"
+
+if [[ $(${SUDO_CMD} ls /etc/apparmor.d/tunables/ | grep -c alias) -ne 0 ]]
+then
+    if [[ $(${SUDO_CMD} cat /etc/apparmor.d/tunables/alias | grep -c ${MYSQL_DATA_DIR}) -eq 0 ]]
+    then
+        ${SUDO_CMD} bash -c "echo \"alias /var/lib/mysql/ -> ${MYSQL_DATA_DIR}/,\" >> /etc/apparmor.d/tunables/alias"
+        ${SUDO_CMD} service apparmor reload
+    fi
+fi
+
+while [ "$ATTEMPTS" -ge  0 ]
+do
+	syslog_netcat "Checking for MySQL instances in $SHORT_HOSTNAME...."
+	${SUDO_CMD} mysql --user=root --password=${MYSQL_ROOT_PASSWORD} -e "SHOW DATABASES;" | grep $MYSQL_DATABASE_NAME
+	if [ $? -eq 0 ]
+	then
+		syslog_netcat "MySQL restarted succesfully on $SHORT_HOSTNAME - OK"
+		if test ${MYSQL_ENABLE_PMM_CLIENT} = 'True'; then
+			if ! grep Ubuntu /etc/lsb-release >/dev/null 2>&1; then
+				syslog_netcat "PMM Client installation only supported on Ubuntu"
+			else
+				${SUDO_CMD} sed -i '/innodb_monitor_enable/d' ${MYSQL_CONF_FILE}
+				${SUDO_CMD} sed -i '/performance_schema/d' ${MYSQL_CONF_FILE}
+				${SUDO_CMD} su -c "echo 'innodb_monitor_enable=all' >> ${MYSQL_CONF_FILE}"
+				${SUDO_CMD} su -c "echo 'performance_schema=ON' >> ${MYSQL_CONF_FILE}"
+				service mysql restart
+
+				wget https://repo.percona.com/apt/percona-release_latest.generic_all.deb
+				sudo dpkg -i percona-release_latest.generic_all.deb
+				sudo apt-get update
+				sudo apt-get -y install pmm-client
+				pmm-admin config --server ${MYSQL_PMM_SERVER}
+				pmm-admin add mysql --user root --password ${MYSQL_ROOT_PASSWORD} --create-user
+				pmm-admin add mysql --user root --password ${MYSQL_ROOT_PASSWORD} --query-source perfschema
+			fi
+		fi
+
+		provision_application_stop $START
+		exit 0
+	else 
+		let ATTEMPTS=ATTEMPTS-1
+		syslog_netcat "Trying to start MySQL"
+		service_stop_disable ${SERVICES[${LINUX_DISTRO}]}
+		service_restart_enable ${SERVICES[${LINUX_DISTRO}]}
+		sleep 10
+		${SUDO_CMD} mysql --user=root --password=${MYSQL_ROOT_PASSWORD} -e "set global max_connect_errors=100000;FLUSH HOSTS;"
+		${SUDO_CMD} mysql --user=root --password=${MYSQL_ROOT_PASSWORD} -e "CREATE DATABASE ${MYSQL_DATABASE_NAME}; "
+		${SUDO_CMD} mysql --user=root --password=${MYSQL_ROOT_PASSWORD} -e "GRANT ALL ON ${MYSQL_DATABASE_NAME}.* TO '${MYSQL_NONROOT_USER}'@'%' IDENTIFIED BY '${MYSQL_NONROOT_PASSWORD}';"
+	fi
+done
+
+syslog_netcat "MySQL could not be restarted on $SHORT_HOSTNAME - NOK"
+exit 2

--- a/scripts/tpcc/cb_run_sysbench.sh
+++ b/scripts/tpcc/cb_run_sysbench.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+source $(echo $0 | sed -e "s/\(.*\/\)*.*/\1.\//g")/cb_common.sh
+
+set_load_gen $@
+
+MYSQL_DATABASE_NAME=`get_my_ai_attribute_with_default mysql_database_name sysbenchdb`
+MYSQL_ROOT_PASSWORD=`get_my_ai_attribute_with_default mysql_root_password temp4now`
+MYSQL_NONROOT_USER=`get_my_ai_attribute_with_default mysql_nonroot_user sysbench`
+MYSQL_NONROOT_PASSWORD=`get_my_ai_attribute_with_default mysql_nonroot_password sysbench`
+MYSQL_DATA_DIR=`get_my_ai_attribute_with_default mysql_data_dir /sysbench`
+
+TPCC_PATH=$(get_my_ai_attribute_with_default tpcc_path /usr/share/sysbench/)
+
+MYSQL_IPS=`get_ips_from_role mysql`
+LOAD_GENERATOR_TARGET_IP=`get_my_ai_attribute load_generator_target_ip`
+TABLES=`get_my_ai_attribute_with_default tables 1`
+SCALE=`get_my_ai_attribute_with_default scale 100`
+
+READ_ONLY=`get_my_ai_attribute_with_default read_only off`
+
+CONN_STR="--mysql-host=${LOAD_GENERATOR_TARGET_IP} --mysql-db=${MYSQL_DATABASE_NAME} --mysql-user=${MYSQL_NONROOT_USER} --mysql-password=${MYSQL_NONROOT_PASSWORD} --db-driver=mysql"
+
+if [[ ${LOAD_ID} == "1" ]]
+then
+    GENERATE_DATA="true"
+    GEN_COMMAND_LINE=""
+else
+    GENERATE_DATA=`get_my_ai_attribute_with_default regenerate_data true`
+    GEN_COMMAND_LINE="${TPCC_PATH}/tpcc.lua ${CONN_STR} cleanup;"
+fi
+
+GENERATE_DATA=$(echo $GENERATE_DATA | tr '[:upper:]' '[:lower:]')
+
+if [[ ${GENERATE_DATA} == "true" ]]
+then
+
+    log_output_command=$(get_my_ai_attribute log_output_command)
+    log_output_command=$(echo ${log_output_command} | tr '[:upper:]' '[:lower:]')
+
+    START_GENERATION=$(get_time)
+
+    syslog_netcat "The value of the parameter \"GENERATE_DATA\" is \"true\". Will generate data for the Sysbench load profile \"${LOAD_PROFILE}\"" 
+	GEN_COMMAND_LINE="${TPCC_PATH}/tpcc.lua ${CONN_STR} --scale=${SCALE} --tables=${TABLES} --threads=${LOAD_LEVEL} prepare"
+    syslog_netcat "Command line is: ${GEN_COMMAND_LINE}"
+    if [[ x"${log_output_command}" == x"true" ]]
+    then
+        syslog_netcat "Command output will be shown"
+        $GEN_COMMAND_LINE 2>&1 | while read line ; do
+            syslog_netcat "$line"
+            echo $line >> $GEN_OUTPUT_FILE
+        done
+        ERROR=$?        
+    else
+        syslog_netcat "Command output will NOT be shown"
+        $GEN_COMMAND_LINE 2>&1 >> $GEN_OUTPUT_FILE
+        ERROR=$?
+    fi
+    END_GENERATION=$(get_time)
+    update_app_errors $ERROR        
+
+    DATA_GENERATION_TIME=$(expr ${END_GENERATION} - ${START_GENERATION})
+    update_app_datagentime ${DATA_GENERATION_TIME}
+	update_app_datagensize $((${SCALE} * ${TABLES}))
+else
+    syslog_netcat "The value of the parameter \"GENERATE_DATA\" is \"false\". Will bypass data generation for the Sysbench load profile \"${LOAD_PROFILE}\""
+    
+fi
+
+CMDLINE="${TPCC_PATH}/tpcc.lua ${CONN_STR} --scale=${SCALE} --tables=${TABLES} --threads=${LOAD_LEVEL} --time=${LOAD_DURATION} run"
+execute_load_generator "${CMDLINE}" ${RUN_OUTPUT_FILE} ${LOAD_DURATION}
+
+tp=$(cat $RUN_OUTPUT_FILE | grep transactions | grep per | cut -d '(' -f 2 | cut -d ' ' -f 1)
+queries=$(cat $RUN_OUTPUT_FILE | grep queries: | grep per | cut -d '(' -f 2 | cut -d ' ' -f 1)
+lat=$(cat $RUN_OUTPUT_FILE | grep avg: | awk '{ print $2 }')
+lat_95=$(cat $RUN_OUTPUT_FILE | grep "95th percentile" | awk '{ print $3 }')
+
+~/cb_report_app_metrics.py \
+datagen_time:$(update_app_datagentime):sec \
+datagen_size:$(update_app_datagensize):records \
+throughput:$tp:tps \
+queries:$queries:qps \
+$(format_for_report latency ${lat}ms) \
+$(format_for_report 95_latency ${lat_95}ms) \
+$(common_metrics)
+
+unset_load_gen
+
+exit 0

--- a/scripts/tpcc/dependencies.txt
+++ b/scripts/tpcc/dependencies.txt
@@ -1,0 +1,39 @@
+### START - Dependency installation order ###
+redis-order = 81
+mysql-order = 82
+sysbench-order = 83
+### END - Dependency installation order ###
+
+### START - Dependency-specific installation method ###
+# pm = "package manager" (yum or apt-get)
+# sl = "soft link" (assume that the dependency is already installed, just has to
+# be properly exposed to the user's path.
+# git = git clone using above giturl
+# pip = python pip utility
+# man = "manual"
+redit-install = pip
+mysql-install = pm
+sysbench-install = pm
+### END - Dependency-specific installation method ###
+
+### START - Tests ###
+redit-configure = redis-cli --version | awk '{ print $2 }'
+mysql-configure = mysql --version | cut -d ' ' -f 6
+sysbench-configure = sysbench --version | awk '{ print $2 }'
+### END - Tests ###
+
+### START - Dependency versions ###
+redis-ver = 2.10.6
+mysql-ver = 2.0
+sysbench-ver = 1.0
+### END - Dependency versions ###
+
+### START - Dependency URLs ###
+
+### END - Dependency URLs ###
+
+### START -  Dependency and method-specific command lines ###
+
+# AUTOMATICALLY EXTRACTED FROM DOCKERFILE ON ../../docker/workload/
+
+### END -  Dependency and method-specific command lines ###

--- a/scripts/tpcc/virtual_application.txt
+++ b/scripts/tpcc/virtual_application.txt
@@ -1,0 +1,88 @@
+# Parameters for this Virtual Application (Application Instance - AI) type should
+# be set on YOUR private configuration configuration file, including the ones 
+# commented.
+
+[AI_TEMPLATES : TPCC] 
+
+# Attributes MANDATORY for all Virtual Applications
+SUT = tpcc->mysql
+LOAD_BALANCER_SUPPORTED = $False
+RESIZE_SUPPORTED = $True
+REGENERATE_DATA = $False 
+LOAD_GENERATOR_ROLE = tpcc
+LOAD_MANAGER_ROLE = tpcc
+METRIC_AGGREGATOR_ROLE = tpcc
+CAPTURE_ROLE = mysql
+LOAD_PROFILE = default
+LOAD_LEVEL = uniformIXIXI1I5
+LOAD_DURATION = 30
+CATEGORY = transactional
+PROFILES = default
+REFERENCE = https://github.com/Percona-Lab/sysbench-tpcc
+LICENSE = Apache_v2
+REPORTED_METRICS = throughput,latency,95_latency,queries,datagen_time,datagen_size,completion_time,errors,quiescent_time
+
+# VApp-specific MANDATORY attributes
+DESCRIPTION =Deploys an instance running the sysbench (TPC-C) load generator and\n
+DESCRIPTION +=one instance running MySQL database.\n
+DESCRIPTION +=  - LOAD_PROFILE possible values: _PROFILES_\n
+DESCRIPTION +=  - LOAD_LEVEL meaning: number of threads on sysbench (parameter --num-threads).\n 
+DESCRIPTION +=  - LOAD_DURATION meaning: for how long should sysbench run.\n
+
+MYSQL_SETUP1 = cb_restart_mysql.sh
+MYSQL_RESET1 = cb_reset_mysql.sh
+START = cb_run_sysbench.sh
+
+# VApp-specific modifier parameters. Commented attributes imply default values assumed
+MYSQL_DATA_DIR = /sysbench
+MYSQL_DATA_FSTYP = ext4
+MYSQL_DATABASE_NAME = sysbenchdb
+MYSQL_ROOT_PASSWORD = temp4now
+MYSQL_NONROOT_USER = sysbench
+MYSQL_NONROOT_PASSWORD = sysbench
+# Scale is the number of warehouses
+SCALE = 100
+# Tables is the number of table sets
+TABLES = 1
+# 100 warehouses with 1 table set produces about 10GB of data in 
+# non-compressed InnoDB tables (so 100 warehouses with 10 table sets gives about 100GB).
+
+# Probably ubuntu-specific. May need to override for CentOS
+MYSQL_CONF_FILE = /etc/mysql/mysql.conf.d/mysqld.cnf
+# Default to 60% of main memory
+MYSQL_RAM_PERCENTAGE = 60
+
+# Default Ubuntu values
+
+# innodb_io_capacity should be set to approximately the number of I/O
+# operations that the system can perform per second. Ideally, keep the setting
+# as low as practical, but not so low that background activities fall behind.
+# If the value is too high, data is removed from the buffer pool and insert
+# buffer too quickly for caching to provide a significant benefit.
+MYSQL_INNODB_IO_CAPACITY = 200
+
+# The combined size of the log files (innodb_log_file_size * innodb_log_files_in_group (= 2))
+# should be large enough that the server can smooth out peaks and troughs in
+# workload activity, which often means that there is enough redo log space to
+# handle more than an hour of write activity. The larger the value, the less
+# checkpoint flush activity is required in the buffer pool, saving disk I/O.
+MYSQL_INNODB_LOG_FILE_SIZE = 48M
+
+# A large query cache size leads to significant performance degradation. This
+# is because of cache overhead and locking. Cacheable queries take out an
+# exclusive lock on MySQL’s query cache. In addition, any insert, update,
+# delete, or other modifications to a table causes any relevant entries in the
+# query cache to be flushed.
+MYSQL_QUERY_CACHE_SIZE = 16M
+
+# The maximum size of internal in-memory temporary tables.
+MYSQL_TMP_TABLE_SIZE = 16M
+
+# The number of open tables for all threads. Increasing this value increases
+# the number of file descriptors that mysqld requires.
+MYSQL_TABLE_OPEN_CACHE = 2000
+
+# Install Percona Monitoring and Management
+MYSQL_ENABLE_PMM_CLIENT = False
+# Connect the Percona Monitoring and Management client to this server IP:port
+MYSQL_PMM_SERVER = 0.0.0.0:80


### PR DESCRIPTION
This is the TPC-C workload from Percona for MySQL in sysbench.
As expected, this is a pretty noisy benchmark, so it is advised to have runs of at least 5 minutes and experiment with the MySQL tunables exposed.

This PR also includes a couple of small fixes we noticed while building the workload.