### PR TITLE
Minor bugs

### DIFF
--- a/lib/clouds/kub_cloud_ops.py
+++ b/lib/clouds/kub_cloud_ops.py
@@ -1115,7 +1115,7 @@ class KubCmds(CommonCloudFunctions) :
                 #      KUB_INITIAL_VMCS = default # use the default namespace, no taints or node names
                 # 2. Forced placement (_taint and _node_name are set in the INITAL_VMCS, like this:
                 #      [USER-DEFINED]
-                #      KUB_INITIAL_VMCS = namespace:taint;nodeName # It's kind of gross. We can make it better later.
+                #      KUB_INITIAL_VMCS = cluster:taint;nodeName # It's kind of gross. We can make it better later.
                 #
                 # The 2nd options requires that you go "taint" the nodes that you want isolated
                 # so that containers from other tenants (or yourself) don't land on in unwanted places.

--- a/lib/stores/stores_initial_setup.py
+++ b/lib/stores/stores_initial_setup.py
@@ -603,7 +603,8 @@ def reset(global_objects, soft = True) :
 
         _msg = "    Flushing Log Store..."
         print _msg,
-        _proc_man.run_os_command("pkill -9 -u " + _logstore_username + " -f rsyslogd")
+        if global_objects["logstore"]["usage"].lower() != "shared" :
+            _proc_man.run_os_command("pkill -9 -u " + _logstore_username + " -f rsyslogd")
         _file_list = []
         _file_list.append("operations.log")
         _file_list.append("report.log")
@@ -616,7 +617,8 @@ def reset(global_objects, soft = True) :
         _file_list.append("subscribe.log")
 
         for _fn in  _file_list :
-            _proc_man.run_os_command("rm -rf " + _log_dir + '/' + _logstore_username + '_' + _fn)
+            if global_objects["logstore"]["usage"].lower() != "shared" :
+                _proc_man.run_os_command("rm -rf " + _log_dir + '/' + _logstore_username + '_' + _fn)
             _proc_man.run_os_command("touch " + _log_dir + '/' + _logstore_username + '_' + _fn)
         _status, _msg = syslog_logstore_setup(global_objects, "check")
         

--- a/scripts/common/cb_common.sh
+++ b/scripts/common/cb_common.sh
@@ -27,7 +27,7 @@ fi
 
 # Get all parameters to connect to the datastore
 cloudname=`cat ~/cb_os_parameters.txt | grep "#OSCN" | cut -d "-" -f 2`
-oshostname=`cat ~/cb_os_parameters.txt | grep "#OSHN" | cut -d "-" -f 2`
+oshostname=`cat ~/cb_os_parameters.txt | grep "#OSHN" | sed "s/OSHN-//g"` # hostnames with `-` in the name weren't working.
 osportnumber=`cat ~/cb_os_parameters.txt | grep "#OSPN" | cut -d "-" -f 2`
 osdatabasenumber=`cat ~/cb_os_parameters.txt | grep "#OSDN" | cut -d "-" -f 2`
 osinstance=`cat ~/cb_os_parameters.txt | grep "#OSOI" | sed 's/#OSOI-//g'`


### PR DESCRIPTION
1. Don't kill rsyslogd if the mode is 'shared'
2. Handle Redis hostnames if the hostname has a `-` character in the hostname