### PR TITLE
Add ability to automatically configure firewall on instances

### DIFF
--- a/configs/templates/internal_options.txt
+++ b/configs/templates/internal_options.txt
@@ -224,6 +224,7 @@ PREPARE_IMAGE_NAME = None
 NEST_CONTAINERS_ENABLED = $False
 NEST_CONTAINERS_REPOSITORY = ibmcb
 NEST_CONTAINERS_INSECURE_REGISTRY = $False
+CONFIGURE_FIREWALL = $True
 # Use the 'openssl' command to choose a password to enable this feature.
 # Requires cloud-init support.
 PASSWORD = $False # Disabled

--- a/lib/operations/base_operations.py
+++ b/lib/operations/base_operations.py
@@ -1551,6 +1551,12 @@ class BaseObjectOperations :
         _log_store = self.osci.get_object(obj_attr_list["cloud_name"], \
                                              "GLOBAL", False, \
                                              "logstore", False)
+        
+        _api_attr_list = self.osci.get_object(obj_attr_list["cloud_name"], \
+                                                       "GLOBAL", \
+                                                       False, \
+                                                       "api_defaults", \
+                                                       False)
 
         obj_attr_list["filestore_host"] = _filestor_attr_list["hostname"]
         obj_attr_list["filestore_port"] = _filestor_attr_list["port"]
@@ -1577,6 +1583,12 @@ class BaseObjectOperations :
         obj_attr_list["objectstore_timeout"] = self.osci.timout
                 
         obj_attr_list["objectstore_protocol"] = "TCP"         
+
+        obj_attr_list["api_host"] = _api_attr_list["hostname"]
+        obj_attr_list["api_port"] = _api_attr_list["port"]
+
+        obj_attr_list["objectstore_dbid"] = self.osci.dbid
+        obj_attr_list["objectstore_timeout"] = self.osci.timout
 
         if obj_attr_list["login"] != "root" :
             obj_attr_list["remote_dir_home"] = "/home/" + obj_attr_list["login"]

--- a/scripts/common/cb_common.sh
+++ b/scripts/common/cb_common.sh
@@ -1121,7 +1121,6 @@ if [ x"$default" != x ] ; then
     hn="${hn}_${self}"
 fi
 
-
 function syslog_netcat {
     # I'm modifying this slightly. There's nothing wrong with logging in scalable mode,
     # except that we should not be calling slow functions in scalable mode. We still
@@ -1150,7 +1149,15 @@ function refresh_hosts_file {
     fi
 
     syslog_netcat "Refreshing hosts file ... "
-    sudo bash -c "rm -f /etc/hosts; echo '127.0.0.1    localhost' >> /etc/hosts; cat ${ai_mapping_file} >> /etc/hosts"
+    echo '127.0.0.1    localhost' > /tmp/hosts
+    echo "${my_ip_addr}   $(hostname)" >> /tmp/hosts
+    for i in objectstore metricstore filestore api vpn_server
+    do
+        echo "$(get_my_vm_attribute ${i}_host)     cb$(echo $i | sed 's/store//g' | sed 's/_server//g') cb${i:0:1}s" >> /tmp/hosts
+    done
+    cat ${ai_mapping_file} >> /tmp/hosts
+    sudo rm -f /etc/hosts
+    sudo mv /tmp/hosts  /etc/hosts
 }
 
 function provision_application_start {
@@ -1257,6 +1264,44 @@ function security_configuration {
     fi
 }
 export -f security_configuration
+
+function configure_firewall {
+    if [[ -z ${LINUX_DISTRO} ]]
+    then
+        linux_distribution
+    fi
+
+    if [[ $IS_CONTAINER -eq 0 ]]
+    then
+        if [[ ${LINUX_DISTRO} -eq 1 ]]
+        then
+            syslog_netcat "Enabling firewall via ufw commands..."
+            sudo ufw --force enable >/dev/null 2>&1
+            sudo ufw allow 22 >/dev/null 2>&1
+            sudo ufw allow $(get_my_vm_attribute ${prov_cloud_port}) >/dev/null 2>&1
+    
+            for i in $(cat /etc/hosts | grep -v 127.0.0.1 | awk '{ print $1 }')
+            do
+                sudo ufw allow from $i 
+            done
+        fi
+
+        if [[ ${LINUX_DISTRO} -eq 2 ]]
+        then
+            syslog_netcat "Enabling firewall via firewall-cmd commands..."
+            _Z=public
+            sudo systemctl start firewalld
+            firewall-cmd --zone ${_Z} --add-port 22/tcp >/dev/null 2>&1
+            firewall-cmd --zone ${_Z} --add-port $(get_my_vm_attribute ${prov_cloud_port})/tcp >/dev/null 2>&1
+    
+            for i in $(cat /etc/hosts | grep -v 127.0.0.1 | awk '{ print $1 }')
+            do
+                firewall-cmd --zone ${_Z} --add-rich-rule="rule family='ipv4' source address=$i accept" 
+            done
+        fi        
+    fi
+}
+export -f configure_firewall
 
 function start_redis {
 

--- a/scripts/common/cb_post_boot.sh
+++ b/scripts/common/cb_post_boot.sh
@@ -69,6 +69,12 @@ then
     sudo virsh net-undefine default >/dev/null 2>&1
 fi
 
+configure_firewall=$(get_my_vm_attribute configure_firewall)
+if [[ $(echo $configure_firewall | tr '[:upper:]' '[:lower:]') == "true" ]]
+then
+    configure_firewall
+fi
+
 post_boot_executed=`get_my_vm_attribute post_boot_executed`
 
 if [[ x"${post_boot_executed}" == x"true" ]]


### PR DESCRIPTION
By setting the attribute CONFIGURE_FIREWALL to $True (default), a new
configure_firewall function will be run during the "post-boot" phase,
making sure that instances can be accessed only by the Orchestrator
node and instances that are part of the same AI. The main use case for
it is public clouds where instances get a directly accessible public IP.
While an experimenter can (and should) configure the cloud-specific
controls for "virtual networking security groups", at a small cost in
terms of code, we can provide a cloud-agnostic solution that should
protect everything out of the box.