### PR TITLE
Add ability to deal with multi-vnic instances

### DIFF
--- a/scripts/common/cb_common.sh
+++ b/scripts/common/cb_common.sh
@@ -2380,9 +2380,9 @@ function run_dhcp_additional_nics {
     then
         NICS_WITH_IP=$(sudo ip -o addr list | grep -Ev 'virbr|docker|tun|xenbr|lxbr|lxdbr|cni|flannel|inet6|[[:space:]]lo[[:space:]]')
         syslog_netcat "Making sure all NICs on this instance have IPs configured ..."
-        for NIC in $(sudo ip -o link list | grep -Ev 'virbr|docker|tun|xenbr|lxbr|lxdbr|cni|flannel|inet6|[[:space:]]lo:[[:space:]]' | awk '{ print $2 }')
+        for NIC in $(sudo ip -o link list | grep -Ev 'virbr|docker|tun|xenbr|lxbr|lxdbr|cni|flannel|inet6|[[:space:]]lo:[[:space:]]' | awk '{ print $2 }' | sed 's/://g')
         do
-            echo "$NICS_WITH_IP" | grep $NIC > /dev/null 2>&1
+            echo "$NICS_WITH_IP" | grep $NIC[[:space:]] > /dev/null 2>&1
             if [[ $? -ne 0 ]]
             then
                 NIC=$(echo $NIC | sed 's/://g')

--- a/scripts/common/cb_common.sh
+++ b/scripts/common/cb_common.sh
@@ -742,7 +742,7 @@ function mount_remote_filesystem {
 }
 export -f mount_remote_filesystem
 
-my_if=$(netstat -rn | grep UG | awk '{ print $8 }')
+my_if=$(netstat -rn | grep UG | awk '{ print $8 }' | head -1)
 my_type=`get_my_vm_attribute type`
 my_login_username=`get_my_vm_attribute login`
 my_remote_dir=`get_my_vm_attribute remote_dir_name`
@@ -1116,7 +1116,7 @@ NC_CMD=${NC}" "${NC_OPTIONS}" "${NC_HOST_SYSLOG}" "${NC_PORT_SYSLOG}
 hn=$(uname -n)
 default=$(/sbin/ip route | grep default)
 if [ x"$default" != x ] ; then
-    interface=$(echo "$default" | sed -e 's/.* dev \+//g' | sed -e "s/ .*//g")
+    interface=$(echo "$default" | sed -e 's/.* dev \+//g' | sed -e "s/ .*//g" | tail -1)
     self=$(/sbin/ifconfig $interface | grep -oE "inet addr:[0-9]+.[0-9]+.[0-9]+.[0-9]+" | sed -e "s/inet addr\://g" | tr "." "-")
     hn="${hn}_${self}"
 fi
@@ -1925,8 +1925,6 @@ function setup_rclocal_restarts {
 }
 
 function automount_data_dirs {
-    #    ROLE_DATA_DIR=$(get_my_ai_attribute_with_default ${my_role}_data_dir none)
-    #    ROLE_DATA_FSTYP=$(get_my_ai_attribute_with_default ${my_role}_data_fstyp local)
 
     check_container
 
@@ -2037,7 +2035,7 @@ defaults
   timeout connect     10s
   timeout client      1m
   timeout server      1m
-  timeout check 	  10s
+  timeout check       10s
   timeout http-keep-alive 300s
   http-reuse safe
   errorfile 400 /etc/haproxy/errors/400.http
@@ -2371,3 +2369,19 @@ function common_metrics {
     echo $mtr_str
 }
 export -f common_metrics
+
+function run_dhcp_additional_nics {
+    NICS_WITH_IP=$(sudo ip -o addr list | grep -Ev 'virbr|docker|tun|xenbr|lxbr|lxdbr|cni|flannel|inet6|[[:space:]]lo[[:space:]]')
+    syslog_netcat "Making sure all NICs on this instance have IPs configured ..."
+    for NIC in $(sudo ip -o link list | grep -Ev 'virbr|docker|tun|xenbr|lxbr|lxdbr|cni|flannel|inet6|[[:space:]]lo:[[:space:]]' | awk '{ print $2 }')
+    do
+        echo "$NICS_WITH_IP" | grep $NIC > /dev/null 2>&1
+        if [[ $? -ne 0 ]]
+        then
+            NIC=$(echo $NIC | sed 's/://g')
+            syslog_netcat "NIC \"$NIC\" seems unconfigured: running dhclient against it"
+            sudo dhclient $NIC
+        fi
+    done            
+}
+export -f run_dhcp_additional_nics

--- a/scripts/common/cb_post_boot.sh
+++ b/scripts/common/cb_post_boot.sh
@@ -58,6 +58,7 @@ then
     setup_rclocal_restarts
 fi
 
+run_dhcp_additional_nics
 refresh_hosts_file
 automount_data_dirs
 fix_ulimit
@@ -79,6 +80,13 @@ else
     post_boot_steps False
     UTC_LOCAL_OFFSET=$(python -c "from time import timezone, localtime, altzone; _ulo = timezone * -1 if (localtime().tm_isdst == 0) else altzone * -1; print _ulo")
     put_my_pending_vm_attribute utc_offset_on_vm $UTC_LOCAL_OFFSET
+
+    EXTRA_NICS_WITH_IP=$(sudo ip -o addr list | grep -Ev 'virbr|docker|tun|xenbr|lxbr|lxdbr|cni|flannel|inet6|[[:space:]]lo[[:space:]]' | grep -v [[:space:]]$my_if[[:space:]] | awk '{ print $2"-"$4}' | cut -d '/' -f 1 | sed ':a;N;$!ba;s/\n/,/g')
+    if [[ ! -z $EXTRA_NICS_WITH_IP ]]
+    then
+        put_my_vm_attribute extra_cloud_ips $EXTRA_NICS_WITH_IP
+    fi
+
     syslog_netcat "Updating \"post_boot_executed\" to \"true\""
     put_my_vm_attribute post_boot_executed true
     provision_generic_stop  


### PR DESCRIPTION
A large portion of CloudBench-supported cloud providers allow for multiple
vnics in a single instance. With this commit, CB can deal with it, not
only by automatically detecting and runnning dhclient on multiple
additional vNICs, but by also collecting all the IP addresses and
storing those on the VM-specific variable "extra_cloud_ips".