### PR TITLE
A more robust and standardized function to set mtu for vnics

### DIFF
--- a/configs/templates/internal_options.txt
+++ b/configs/templates/internal_options.txt
@@ -224,6 +224,7 @@ PREPARE_IMAGE_NAME = None
 NEST_CONTAINERS_ENABLED = $False
 NEST_CONTAINERS_REPOSITORY = ibmcb
 NEST_CONTAINERS_INSECURE_REGISTRY = $False
+CONFIGURE_FIREWALL = $True
 # Use the 'openssl' command to choose a password to enable this feature.
 # Requires cloud-init support.
 PASSWORD = $False # Disabled

--- a/lib/operations/base_operations.py
+++ b/lib/operations/base_operations.py
@@ -1551,6 +1551,12 @@ class BaseObjectOperations :
         _log_store = self.osci.get_object(obj_attr_list["cloud_name"], \
                                              "GLOBAL", False, \
                                              "logstore", False)
+        
+        _api_attr_list = self.osci.get_object(obj_attr_list["cloud_name"], \
+                                                       "GLOBAL", \
+                                                       False, \
+                                                       "api_defaults", \
+                                                       False)
 
         obj_attr_list["filestore_host"] = _filestor_attr_list["hostname"]
         obj_attr_list["filestore_port"] = _filestor_attr_list["port"]
@@ -1577,6 +1583,12 @@ class BaseObjectOperations :
         obj_attr_list["objectstore_timeout"] = self.osci.timout
                 
         obj_attr_list["objectstore_protocol"] = "TCP"         
+
+        obj_attr_list["api_host"] = _api_attr_list["hostname"]
+        obj_attr_list["api_port"] = _api_attr_list["port"]
+
+        obj_attr_list["objectstore_dbid"] = self.osci.dbid
+        obj_attr_list["objectstore_timeout"] = self.osci.timout
 
         if obj_attr_list["login"] != "root" :
             obj_attr_list["remote_dir_home"] = "/home/" + obj_attr_list["login"]

--- a/scripts/common/cb_common.sh
+++ b/scripts/common/cb_common.sh
@@ -1121,7 +1121,6 @@ if [ x"$default" != x ] ; then
     hn="${hn}_${self}"
 fi
 
-
 function syslog_netcat {
     # I'm modifying this slightly. There's nothing wrong with logging in scalable mode,
     # except that we should not be calling slow functions in scalable mode. We still
@@ -1150,7 +1149,15 @@ function refresh_hosts_file {
     fi
 
     syslog_netcat "Refreshing hosts file ... "
-    sudo bash -c "rm -f /etc/hosts; echo '127.0.0.1    localhost' >> /etc/hosts; cat ${ai_mapping_file} >> /etc/hosts"
+    echo '127.0.0.1    localhost' > /tmp/hosts
+    echo "${my_ip_addr}   $(hostname)" >> /tmp/hosts
+    for i in objectstore metricstore filestore api vpn_server
+    do
+        echo "$(get_my_vm_attribute ${i}_host)     cb$(echo $i | sed 's/store//g' | sed 's/_server//g') cb${i:0:1}s" >> /tmp/hosts
+    done
+    cat ${ai_mapping_file} >> /tmp/hosts
+    sudo rm -f /etc/hosts
+    sudo mv /tmp/hosts  /etc/hosts
 }
 
 function provision_application_start {
@@ -1257,6 +1264,44 @@ function security_configuration {
     fi
 }
 export -f security_configuration
+
+function configure_firewall {
+    if [[ -z ${LINUX_DISTRO} ]]
+    then
+        linux_distribution
+    fi
+
+    if [[ $IS_CONTAINER -eq 0 ]]
+    then
+        if [[ ${LINUX_DISTRO} -eq 1 ]]
+        then
+            syslog_netcat "Enabling firewall via ufw commands..."
+            sudo ufw --force enable >/dev/null 2>&1
+            sudo ufw allow 22 >/dev/null 2>&1
+            sudo ufw allow $(get_my_vm_attribute ${prov_cloud_port}) >/dev/null 2>&1
+    
+            for i in $(cat /etc/hosts | grep -v 127.0.0.1 | awk '{ print $1 }')
+            do
+                sudo ufw allow from $i 
+            done
+        fi
+
+        if [[ ${LINUX_DISTRO} -eq 2 ]]
+        then
+            syslog_netcat "Enabling firewall via firewall-cmd commands..."
+            _Z=public
+            sudo systemctl start firewalld
+            firewall-cmd --zone ${_Z} --add-port 22/tcp >/dev/null 2>&1
+            firewall-cmd --zone ${_Z} --add-port $(get_my_vm_attribute ${prov_cloud_port})/tcp >/dev/null 2>&1
+    
+            for i in $(cat /etc/hosts | grep -v 127.0.0.1 | awk '{ print $1 }')
+            do
+                firewall-cmd --zone ${_Z} --add-rich-rule="rule family='ipv4' source address=$i accept" 
+            done
+        fi        
+    fi
+}
+export -f configure_firewall
 
 function start_redis {
 

--- a/scripts/common/cb_common.sh
+++ b/scripts/common/cb_common.sh
@@ -2438,3 +2438,22 @@ function run_dhcp_additional_nics {
     fi
 }
 export -f run_dhcp_additional_nics
+
+function set_nic_mtu {
+    IF_MTU=$(get_my_ai_attribute_with_default if_mtu auto)
+    if [[ ${IF_MTU} != "auto" ]]
+    then
+        syslog_netcat "Setting MTU for interface \"${my_if}\" to \"${IF_MTU}\" ..."                
+        sudo ifconfig $my_if mtu ${IF_MTU}
+        _NEW_MTU=$(ifconfig $my_if | grep mtu | awk '{ print $4 }')
+        if [[ ${_NEW_MTU} != ${IF_MTU} ]]
+        then
+            syslog_netcat "ERROR: unable to set correct MTU (${IF_MTU}) for \"${my_if}\"!"
+            exit 1
+        else
+            syslog_netcat "Correct MTU (${IF_MTU}) set for \"${my_if}\"!"
+        fi
+    fi
+
+}
+export -f set_nic_mtu

--- a/scripts/common/cb_post_boot.sh
+++ b/scripts/common/cb_post_boot.sh
@@ -69,6 +69,12 @@ then
     sudo virsh net-undefine default >/dev/null 2>&1
 fi
 
+configure_firewall=$(get_my_vm_attribute configure_firewall)
+if [[ $(echo $configure_firewall | tr '[:upper:]' '[:lower:]') == "true" ]]
+then
+    configure_firewall
+fi
+
 post_boot_executed=`get_my_vm_attribute post_boot_executed`
 
 if [[ x"${post_boot_executed}" == x"true" ]]

--- a/scripts/common/cb_post_boot.sh
+++ b/scripts/common/cb_post_boot.sh
@@ -93,6 +93,8 @@ else
         put_my_vm_attribute extra_cloud_ips $EXTRA_NICS_WITH_IP
     fi
 
+    set_nic_mtu
+
     syslog_netcat "Updating \"post_boot_executed\" to \"true\""
     put_my_vm_attribute post_boot_executed true
     provision_generic_stop  

--- a/scripts/common/cb_post_boot.sh
+++ b/scripts/common/cb_post_boot.sh
@@ -58,6 +58,7 @@ then
     setup_rclocal_restarts
 fi
 
+run_dhcp_additional_nics
 refresh_hosts_file
 automount_data_dirs
 fix_ulimit
@@ -85,6 +86,13 @@ else
     post_boot_steps False
     UTC_LOCAL_OFFSET=$(python -c "from time import timezone, localtime, altzone; _ulo = timezone * -1 if (localtime().tm_isdst == 0) else altzone * -1; print _ulo")
     put_my_pending_vm_attribute utc_offset_on_vm $UTC_LOCAL_OFFSET
+
+    EXTRA_NICS_WITH_IP=$(sudo ip -o addr list | grep -Ev 'virbr|docker|tun|xenbr|lxbr|lxdbr|cni|flannel|inet6|[[:space:]]lo[[:space:]]' | grep -v [[:space:]]$my_if[[:space:]] | awk '{ print $2"-"$4}' | cut -d '/' -f 1 | sed ':a;N;$!ba;s/\n/,/g')
+    if [[ ! -z $EXTRA_NICS_WITH_IP ]]
+    then
+        put_my_vm_attribute extra_cloud_ips $EXTRA_NICS_WITH_IP
+    fi
+
     syslog_netcat "Updating \"post_boot_executed\" to \"true\""
     put_my_vm_attribute post_boot_executed true
     provision_generic_stop  

--- a/scripts/iperf/cb_check_iperf_server.sh
+++ b/scripts/iperf/cb_check_iperf_server.sh
@@ -33,13 +33,6 @@ else
     provision_application_stop $START
 fi
 
-IF_MTU=$(get_my_ai_attribute_with_default if_mtu auto)
-
-if [[ ${IF_MTU} != "auto" ]]
-then
-    sudo ifconfig $my_if mtu ${IF_MTU}
-fi
-
 LOAD_PROFILE=$(get_my_ai_attribute load_profile)
 
 is_iperfserver_running=$(sudo ps aux | grep iperf | grep -v grep | grep "\-s")

--- a/scripts/iperf/cb_run_iperf.sh
+++ b/scripts/iperf/cb_run_iperf.sh
@@ -25,14 +25,8 @@ LOAD_GENERATOR_TARGET_IP=$(get_my_ai_attribute load_generator_target_ip)
 
 TRAFFIC_MSS=$(get_my_ai_attribute_with_default traffic_mss auto)
 RATE_LIMIT=$(get_my_ai_attribute_with_default rate_limit auto)
-IF_MTU=$(get_my_ai_attribute_with_default if_mtu auto)
 BUFFER_LENGTH=$(get_my_ai_attribute_with_default buffer_length auto)
 EXTERNAL_TARGET=$(get_my_ai_attribute_with_default external_target none)
-
-if [[ ${IF_MTU} != "auto" ]]
-then
-    sudo ifconfig $my_if mtu ${IF_MTU}
-fi
 
 iperf=$(which iperf)
 

--- a/scripts/netperf/cb_run_netperf.sh
+++ b/scripts/netperf/cb_run_netperf.sh
@@ -27,20 +27,12 @@ netperf=$(which netperf)
 
 LOAD_PROFILE=$(echo ${LOAD_PROFILE} | tr '[:upper:]' '[:lower:]')
 
-
 SEND_BUFFER_SIZE=$(get_my_ai_attribute_with_default send_buffer_size auto)
 RECV_BUFFER_SIZE=$(get_my_ai_attribute_with_default recv_buffer_size auto)
 CLIENT_BUFFER_SIZE=$(get_my_ai_attribute_with_default client_buffer_size auto)
 SERVER_BUFFER_SIZE=$(get_my_ai_attribute_with_default server_buffer_size auto)
 REQUEST_RESPONSE_SIZE=$(get_my_ai_attribute_with_default request_response_size auto)
-IF_MTU=$(get_my_ai_attribute_with_default if_mtu auto)
 EXTERNAL_TARGET=$(get_my_ai_attribute_with_default external_target none)
-    
-if [[ ${IF_MTU} != "auto" ]]
-then
-    sudo ifconfig $my_if mtu ${IF_MTU}
-fi
-
 declare -A CMDLINE_START
 
 CMDLINE_START["tcp_stream"]="-t TCP_STREAM"

--- a/scripts/nuttcp/cb_run_nuttcp.sh
+++ b/scripts/nuttcp/cb_run_nuttcp.sh
@@ -27,13 +27,7 @@ TRAFFIC_DIRECTION=$(get_my_ai_attribute_with_default traffic_direction r)
 TRAFFIC_MSS=$(get_my_ai_attribute_with_default traffic_mss auto)
 TRAFFIC_WINDOW=$(get_my_ai_attribute_with_default traffic_window auto)
 RATE_LIMIT=$(get_my_ai_attribute_with_default rate_limit none)
-IF_MTU=$(get_my_ai_attribute_with_default if_mtu auto)
 EXTERNAL_TARGET=$(get_my_ai_attribute_with_default external_target none)
-    
-if [[ ${IF_MTU} != "auto" ]]
-then
-    sudo ifconfig $my_if mtu ${IF_MTU}
-fi
 
 nuttcp=$(which nuttcp)
 

--- a/scripts/xping/cb_run_xping.sh
+++ b/scripts/xping/cb_run_xping.sh
@@ -25,13 +25,7 @@ LOAD_GENERATOR_TARGET_IP=$(get_my_ai_attribute load_generator_target_ip)
 
 PACKET_SIZE=$(get_my_ai_attribute_with_default packet_size auto)
 PACKET_TTL=$(get_my_ai_attribute_with_default packet_ttl auto)
-IF_MTU=$(get_my_ai_attribute_with_default if_mtu auto)
 EXTERNAL_TARGET=$(get_my_ai_attribute_with_default external_target none)
-    
-if [[ ${IF_MTU} != "auto" ]]
-then
-    sudo ifconfig $my_if mtu ${IF_MTU}
-fi
 
 ping=$(which ping)
 


### PR DESCRIPTION
In addition to a new function (`set_mtu`) which is common to all
workloads (and will fail in case it does not succeed in setting the
specified mtu), this commit also makes sure that all network-centric
workloads properly uses this function (this is done mostly by removing
old duplicated code)