### PR TITLE
A more robust and standardized function to set mtu for vnics

### DIFF
--- a/scripts/common/cb_common.sh
+++ b/scripts/common/cb_common.sh
@@ -2438,3 +2438,22 @@ function run_dhcp_additional_nics {
     fi
 }
 export -f run_dhcp_additional_nics
+
+function set_nic_mtu {
+    IF_MTU=$(get_my_ai_attribute_with_default if_mtu auto)
+    if [[ ${IF_MTU} != "auto" ]]
+    then
+        syslog_netcat "Setting MTU for interface \"${my_if}\" to \"${IF_MTU}\" ..."                
+        sudo ifconfig $my_if mtu ${IF_MTU}
+        _NEW_MTU=$(ifconfig $my_if | grep mtu | awk '{ print $4 }')
+        if [[ ${_NEW_MTU} != ${IF_MTU} ]]
+        then
+            syslog_netcat "ERROR: unable to set correct MTU (${IF_MTU}) for \"${my_if}\"!"
+            exit 1
+        else
+            syslog_netcat "Correct MTU (${IF_MTU}) set for \"${my_if}\"!"
+        fi
+    fi
+
+}
+export -f set_nic_mtu

--- a/scripts/common/cb_post_boot.sh
+++ b/scripts/common/cb_post_boot.sh
@@ -93,6 +93,8 @@ else
         put_my_vm_attribute extra_cloud_ips $EXTRA_NICS_WITH_IP
     fi
 
+    set_nic_mtu
+
     syslog_netcat "Updating \"post_boot_executed\" to \"true\""
     put_my_vm_attribute post_boot_executed true
     provision_generic_stop  

--- a/scripts/iperf/cb_check_iperf_server.sh
+++ b/scripts/iperf/cb_check_iperf_server.sh
@@ -33,13 +33,6 @@ else
     provision_application_stop $START
 fi
 
-IF_MTU=$(get_my_ai_attribute_with_default if_mtu auto)
-
-if [[ ${IF_MTU} != "auto" ]]
-then
-    sudo ifconfig $my_if mtu ${IF_MTU}
-fi
-
 LOAD_PROFILE=$(get_my_ai_attribute load_profile)
 
 is_iperfserver_running=$(sudo ps aux | grep iperf | grep -v grep | grep "\-s")

--- a/scripts/iperf/cb_run_iperf.sh
+++ b/scripts/iperf/cb_run_iperf.sh
@@ -25,14 +25,8 @@ LOAD_GENERATOR_TARGET_IP=$(get_my_ai_attribute load_generator_target_ip)
 
 TRAFFIC_MSS=$(get_my_ai_attribute_with_default traffic_mss auto)
 RATE_LIMIT=$(get_my_ai_attribute_with_default rate_limit auto)
-IF_MTU=$(get_my_ai_attribute_with_default if_mtu auto)
 BUFFER_LENGTH=$(get_my_ai_attribute_with_default buffer_length auto)
 EXTERNAL_TARGET=$(get_my_ai_attribute_with_default external_target none)
-
-if [[ ${IF_MTU} != "auto" ]]
-then
-    sudo ifconfig $my_if mtu ${IF_MTU}
-fi
 
 iperf=$(which iperf)
 

--- a/scripts/netperf/cb_run_netperf.sh
+++ b/scripts/netperf/cb_run_netperf.sh
@@ -27,19 +27,12 @@ netperf=$(which netperf)
 
 LOAD_PROFILE=$(echo ${LOAD_PROFILE} | tr '[:upper:]' '[:lower:]')
 
-
 SEND_BUFFER_SIZE=$(get_my_ai_attribute_with_default send_buffer_size auto)
 RECV_BUFFER_SIZE=$(get_my_ai_attribute_with_default recv_buffer_size auto)
 CLIENT_BUFFER_SIZE=$(get_my_ai_attribute_with_default client_buffer_size auto)
 SERVER_BUFFER_SIZE=$(get_my_ai_attribute_with_default server_buffer_size auto)
 REQUEST_RESPONSE_SIZE=$(get_my_ai_attribute_with_default request_response_size auto)
-IF_MTU=$(get_my_ai_attribute_with_default if_mtu auto)
 EXTERNAL_TARGET=$(get_my_ai_attribute_with_default external_target none)
-    
-if [[ ${IF_MTU} != "auto" ]]
-then
-    sudo ifconfig $my_if mtu ${IF_MTU}
-fi
 
 declare -A CMDLINE_START
 

--- a/scripts/nuttcp/cb_run_nuttcp.sh
+++ b/scripts/nuttcp/cb_run_nuttcp.sh
@@ -27,13 +27,7 @@ TRAFFIC_DIRECTION=$(get_my_ai_attribute_with_default traffic_direction r)
 TRAFFIC_MSS=$(get_my_ai_attribute_with_default traffic_mss auto)
 TRAFFIC_WINDOW=$(get_my_ai_attribute_with_default traffic_window auto)
 RATE_LIMIT=$(get_my_ai_attribute_with_default rate_limit none)
-IF_MTU=$(get_my_ai_attribute_with_default if_mtu auto)
 EXTERNAL_TARGET=$(get_my_ai_attribute_with_default external_target none)
-    
-if [[ ${IF_MTU} != "auto" ]]
-then
-    sudo ifconfig $my_if mtu ${IF_MTU}
-fi
 
 nuttcp=$(which nuttcp)
 

--- a/scripts/xping/cb_run_xping.sh
+++ b/scripts/xping/cb_run_xping.sh
@@ -25,13 +25,7 @@ LOAD_GENERATOR_TARGET_IP=$(get_my_ai_attribute load_generator_target_ip)
 
 PACKET_SIZE=$(get_my_ai_attribute_with_default packet_size auto)
 PACKET_TTL=$(get_my_ai_attribute_with_default packet_ttl auto)
-IF_MTU=$(get_my_ai_attribute_with_default if_mtu auto)
 EXTERNAL_TARGET=$(get_my_ai_attribute_with_default external_target none)
-    
-if [[ ${IF_MTU} != "auto" ]]
-then
-    sudo ifconfig $my_if mtu ${IF_MTU}
-fi
 
 ping=$(which ping)
 


### PR DESCRIPTION
In addition to a new function (set_mtu) which is common to all
workloads (and will fail in case it does not succeed in setting the
specified mtu), this commit also makes sure that all network-centric
workloads properly uses this function (this is done mostly by removing
old duplicated code)