### PR TITLE
Incorporate a basic destroy-time backoff mechanism

### DIFF
--- a/configs/templates/internal_options.txt
+++ b/configs/templates/internal_options.txt
@@ -150,6 +150,11 @@ ADDITIONAL_DISCOVERY = $EMPTY
 # Colocate will make sure that all VMs of the same AI go to the same VMC
 # You can also do "colocate,roundrobin" or "colocate,random" which will do both at the same time
 PLACEMENT_METHOD = roundrobin 
+# Crude backoff mechanism at startup time,
+# currently only implemented within the libcloud adapter.
+# A similar mechanism (using the same code) is also
+# available separately (below) for vmdetach
+MAX_BACKOFF = $False
 
 [VM_DEFAULTS]
 DETACH_ATTEMPTS = 1
@@ -231,6 +236,14 @@ PASSWORD = $False # Disabled
 CLOUDINIT_PACKAGES = $False
 CLOUDINIT_COMMANDS = $False
 CLOUDINIT_KEYS = $Empty
+# This backoff is cloud-agnostic. It's implemented
+# for vmdestroy() in the face of errors of the
+# cloud. If true, in coordination with the variable
+# DETACH_ATTEMPTS, we will not only attempt to
+# retry the detach forever, but we will also backoff
+# by doubling the wait interval to the following
+# maximum value (in seconds)
+MAX_BACKOFF = $False
 
 [AI_DEFAULTS]
 USERNAME = $MAIN_USERNAME

--- a/lib/clouds/libcloud_common.py
+++ b/lib/clouds/libcloud_common.py
@@ -565,6 +565,7 @@ class LibcloudCmds(CommonCloudFunctions) :
             for credentials_list in obj_attr_list["credentials"].split(";"):
                 _status, _msg, _local_conn, _hostname = self.connect(credentials_list)
 
+            _wait = int(obj_attr_list["update_frequency"])
             _existing_instances = True
             while _existing_instances :
                 _existing_instances = False
@@ -604,10 +605,11 @@ class LibcloudCmds(CommonCloudFunctions) :
                             _msg = "Cleaning up " + self.get_description() + ".  Ignoring instance: " + _reservation.name
                             cbdebug(_msg)
 
-                    if _existing_instances :
-                        sleep(int(obj_attr_list["update_frequency"]))
+                if _existing_instances :
+                    _wait = self.backoff(obj_attr_list, _wait)
 
             if self.use_volumes :
+                _wait = int(obj_attr_list["update_frequency"])
                 _running_volumes = True
                 while _running_volumes :
                     _running_volumes = False
@@ -636,8 +638,7 @@ class LibcloudCmds(CommonCloudFunctions) :
                                 cbdebug(_msg)
 
                         if _running_volumes :
-                            sleep(int(obj_attr_list["update_frequency"]))
-
+                            _wait = self.backoff(obj_attr_list, _wait)
             _status = 0
 
         except CldOpsException, obj :

--- a/lib/clouds/shared_functions.py
+++ b/lib/clouds/shared_functions.py
@@ -1735,7 +1735,7 @@ packages:"""
             else:
                 cbwarn(obj_attr_list["name"] + ": Problem with instance destroy, trying again...", True)
 
-            sleep(_wait)
+            _wait = self.backoff(obj_attr_list, _wait)
 
             _status, _fmsg = self.vmdestroy_repeat_and_check(obj_attr_list)
 
@@ -2072,3 +2072,13 @@ packages:"""
         finally :
             _status, _msg = self.common_messages("AI", obj_attr_list, "undefined", _status, _fmsg)
             return _status, _msg
+
+    @trace
+    def backoff(self, obj_attr_list, delay) :
+        # Sleep and simply double the delay
+        sleep(delay)
+        if "max_backoff" in obj_attr_list and str(obj_attr_list["max_backoff"]).lower() != "false" :
+            delay = min(delay * 2, int(obj_attr_list["max_backoff"]))
+            cbdebug("Backoff increased to " + str(delay) + " seconds.", True) 
+        return delay
+


### PR DESCRIPTION
A common error-handling issue with public clouds is detaching VMs.

Currently, we have a mechanism already (that we depend on a lot, actually)
that will attempt to repetively detach resources forever until it succeeds.
This is really important when we are spending money on a public cloud
running a benchmark.

This commit allows this mechanism to backoff during this waiting period.
Rather than re-submit the same detach request every 5 seconds, it provides
a very simple backoff mechanism that you can configure a maximum for,
so that we don't inundate the cloud with too many operations to perform,
particularly if the cloud is transiently unavailable.