### PR TITLE
Don't use the public network if a load balancer is not enabled

### DIFF
--- a/lib/clouds/shared_functions.py
+++ b/lib/clouds/shared_functions.py
@@ -2085,6 +2085,6 @@ packages:"""
         sleep(delay)
         if "max_backoff" in obj_attr_list and str(obj_attr_list["max_backoff"]).lower() != "false" :
             delay = min(delay * 2, int(obj_attr_list["max_backoff"]))
-            cbdebug("Backoff increased to " + str(delay) + " seconds.", True) 
+            cbdebug("Backoff increased to " + str(delay) + " seconds.", False if "update_frequency" in obj_attr_list and (delay > (int(obj_attr_list["update_frequency"]) * 2)) else True)
         return delay
 

--- a/lib/operations/base_operations.py
+++ b/lib/operations/base_operations.py
@@ -2445,7 +2445,7 @@ class BaseObjectOperations :
                                                                  False)
 
                             obj_attr_list["load_generator_target_vm"] += _vm_uuid + ','
-                            if str(obj_attr_list["use_public_lb_network"]).lower() == "true" :
+                            if "load_balancer_target_role" in obj_attr_list and obj_attr_list["load_balancer_target_role"] != "none" and str(obj_attr_list["use_public_lb_network"]).lower() == "true" :
                                 obj_attr_list["load_generator_target_ip"] += _vm_attr_list["public_cloud_ip"] + ','
                             else :
                                 obj_attr_list["load_generator_target_ip"] += _vm_attr_list["run_cloud_ip"] + ','


### PR DESCRIPTION
Previously (for the wrk2 workload), we introduced a change that
allowed ingress haproxy traffic to come in over the public network, while
allowing egress haproxy traffic to exit over the private network to
mimic our customers.

Don't do this if there is no haproxy in the picture. =)

The problem with doing this is that the firewall will block this traffic
if we really wanted.

As a result, I have also included a patch that allows access on the public
network for the firewall only from other dropls (just like the private network).