### PR TITLE
Don't flush shared logs

### DIFF
--- a/lib/operations/base_operations.py
+++ b/lib/operations/base_operations.py
@@ -3974,7 +3974,8 @@ class BaseObjectOperations :
                 _msg = "Flushing Log Store..."
                 cbdebug(_msg, True)
                 
-                _proc_man.run_os_command("pkill -9 -u " + _logstore_username + " -f rsyslogd")
+                if _logstore_attr_list["usage"].lower() != "shared" :
+                    _proc_man.run_os_command("pkill -9 -u " + _logstore_username + " -f rsyslogd")
                 _file_list = []
                 _file_list.append("operations.log")
                 _file_list.append("report.log")

--- a/lib/operations/base_operations.py
+++ b/lib/operations/base_operations.py
@@ -3986,9 +3986,10 @@ class BaseObjectOperations :
                 _file_list.append("subscribe.log")
                 _file_list.append("staging.log")
                     
-                for _fn in  _file_list :
-                    _proc_man.run_os_command("rm -rf " + _log_dir + '/' + _logstore_username + '_' + _fn)
-                    _proc_man.run_os_command("touch " + _log_dir + '/' + _logstore_username + '_' + _fn)
+                if _logstore_attr_list["usage"].lower() != "shared" :
+                    for _fn in  _file_list :
+                        _proc_man.run_os_command("rm -rf " + _log_dir + '/' + _logstore_username + '_' + _fn)
+                        _proc_man.run_os_command("touch " + _log_dir + '/' + _logstore_username + '_' + _fn)
                     
                 _status, _msg = syslog_logstore_setup(_global_objects, "check")
 


### PR DESCRIPTION
Don't delete the logs from /var/log/cloudbench if the logstore is in shared mode.