### PR TITLE
Opt-in to extended [host]names

### DIFF
--- a/configs/templates/internal_options.txt
+++ b/configs/templates/internal_options.txt
@@ -244,6 +244,9 @@ CLOUDINIT_KEYS = $Empty
 # by doubling the wait interval to the following
 # maximum value (in seconds)
 MAX_BACKOFF = $False
+# "extended" means that we will append the AI name and VM roles
+# to the end of the hostname for rsyslog purposes.
+EXTENDED_NAMES = $False
 
 [AI_DEFAULTS]
 USERNAME = $MAIN_USERNAME

--- a/lib/clouds/gce_cloud_ops.py
+++ b/lib/clouds/gce_cloud_ops.py
@@ -94,8 +94,6 @@ class GceCmds(CommonCloudFunctions) :
             if _credentials.create_scoped_required():
                 _credentials = _credentials.create_scoped('https://www.googleapis.com/auth/compute')
 
-            self.gceconn = build('compute', 'v1', credentials=_credentials)
-
             _http_conn_id = "common"
             if http_conn_id :
                 _http_conn_id = http_conn_id
@@ -103,7 +101,8 @@ class GceCmds(CommonCloudFunctions) :
             if _http_conn_id not in self.http_conn :
                 self.http_conn[_http_conn_id] = _credentials.authorize(http = httplib2shim.Http())
 
-            _zone_list = self.gceconn.zones().list(project=self.instances_project).execute()["items"]
+            self.gceconn = build('compute', 'v1', http = self.http_conn[http_conn_id])
+            _zone_list = self.gceconn.zones().list(project=self.instances_project).execute(http = self.http_conn[http_conn_id])["items"]
 
             _zone_info = False
             for _idx in range(0,len(_zone_list)) :

--- a/lib/clouds/shared_functions.py
+++ b/lib/clouds/shared_functions.py
@@ -1632,13 +1632,15 @@ packages:"""
             obj_attr_list["cloud_vm_name"] += '-' + obj_attr_list["cloud_name"]
             obj_attr_list["cloud_vm_name"] += '-' + "vm"
             obj_attr_list["cloud_vm_name"] += obj_attr_list["name"].split("_")[1]
-            obj_attr_list["cloud_vm_name"] += '-' + obj_attr_list["role"]
-            
-            if obj_attr_list["ai"] != "none" :            
-                obj_attr_list["cloud_vm_name"] += '-' + obj_attr_list["ai_name"]  
 
-            if "vm_name_suffix" in obj_attr_list :
-                obj_attr_list["cloud_vm_name"] = obj_attr_list["cloud_vm_name"] + '-' + obj_attr_list["vm_name_suffix"]
+            if "extended_names" in obj_attr_list and str(obj_attr_list["extended_names"]).lower() == "true" :
+                obj_attr_list["cloud_vm_name"] += '-' + obj_attr_list["role"]
+
+                if obj_attr_list["ai"] != "none" :
+                    obj_attr_list["cloud_vm_name"] += '-' + obj_attr_list["ai_name"]
+
+                if "vm_name_suffix" in obj_attr_list :
+                    obj_attr_list["cloud_vm_name"] = obj_attr_list["cloud_vm_name"] + '-' + obj_attr_list["vm_name_suffix"]
 
         if "cloud_vv_name" not in obj_attr_list :       
             obj_attr_list["cloud_vv_name"] = "cb-" + obj_attr_list["username"]


### PR DESCRIPTION
"extended" means that we will append the AI name and VM roles
to the end of the VM's name for rsyslog purposes. This is rather
convenient because it translates to the VM's hostname which makes
log messages easier to lookup when you know the AI and role information.

Let's default this functionality to false, because it can unpredictably reach the Linux
64-byte hostname limit. The remainer of the hostname is under the control of the user,
because they can pick what the "name" of the cloud should be.

If you want the additional information available to you in rsyslog messages,
then you can "opt-in" here by setting it to $True