### PR TITLE
Fix python3 syntax

### DIFF
--- a/lib/api/api_service_client.py
+++ b/lib/api/api_service_client.py
@@ -32,12 +32,17 @@
 '''
 
 from sys import path
-from xmlrpclib import Server
-import xmlrpclib
 import pwd
 import sys
 import re
 import os
+
+if sys.version_info[0] < 3:
+    from xmlrpclib import Server
+    import xmlrpclib
+else:
+    from xmlrpc.client import ServerProxy as Server
+    import xmlrpc.client as xmlrpclib
 
 path.append(re.compile(".*\/").search(os.path.realpath(__file__)).group(0) + "/../../")
 path.append(re.compile(".*\/").search(os.path.realpath(__file__)).group(0) + "/../../../")
@@ -137,13 +142,13 @@ class APIClient(Server):
                 mutex.acquire()
                 resp = func(*args, **kwargs)
                 mutex.release()
-            except Exception, e :
+            except Exception as e :
                 mutex.release()
                 raise e
             if int(resp["status"]) :
                 raise APIException(str(resp["status"]), resp["msg"])
             if self.print_message :
-                print resp["msg"]
+                print(resp["msg"])
             return resp["result"]
         return wrapped
 
@@ -209,10 +214,10 @@ class APIClient(Server):
         TBD
         '''
         info = self.vmshow(cloud_name, identifier)
-        print identifier + " configured: (" + info["vcpus"] + ", " + info["vmemory"] + ")"
+        print(identifier + " configured: (" + info["vcpus"] + ", " + info["vmemory"] + ")")
 
         if "configured_size" in info :
-            print "   Eclipsed size: (" + info["vcpus_max"] + ", " + info["vmemory_max"] + ")"
+            print("   Eclipsed size: (" + info["vcpus_max"] + ", " + info["vmemory_max"] + ")")
 
         if info["ai"] != "none" :
             app = self.appshow(cloud_name, info["ai_name"])
@@ -268,12 +273,12 @@ class APIClient(Server):
             self.reset_refresh(cloud_name)
             return True
 
-        except APIException, obj :
-            print "Check VM API Problem (" + str(obj.status) + "): " + obj.msg
+        except APIException as obj :
+            print("Check VM API Problem (" + str(obj.status) + "): " + obj.msg)
             return False
 
-        except socket.error, obj :
-            print "API not available: " + str(obj)
+        except socket.error as obj :
+            print("API not available: " + str(obj))
             return False
 
     def get_performance_data(self, cloud_name, uuid, metric_class = "runtime", object_type = "VM", metric_type = "os", latest = False, samples = 0, expid = "auto") :

--- a/lib/auxiliary/code_instrumentation.py
+++ b/lib/auxiliary/code_instrumentation.py
@@ -32,14 +32,12 @@ from itertools import chain
 from collections import deque
 import sys
 import socket
-import __builtin__
 
 try:
     from reprlib import repr
 except ImportError:
     pass
 
-bins = dir(__builtin__)
 
 DEBUG = logging.DEBUG
 INFO = logging.INFO
@@ -68,7 +66,7 @@ def trace_actual(aFunc):
         
         try:
             result = aFunc(*args, **kwargs )
-        except Exception, e:
+        except Exception as e:
             _msg = _log_prefix + " - Exit point (Exception \"" + str(e) + "\") "
             _msg += _log_suffix
             logging.debug(_msg)
@@ -143,7 +141,7 @@ def _cblog(*args):
         _msg = _log_prefix + ' ' + _procid + " - " + _msg + _log_suffix
         _log_severity[_severity](_msg)
     
-    except Exception, msg :
+    except Exception as msg :
         print ("exception: " + str(msg) + " : " + _msg)
 
     return True

--- a/lib/auxiliary/config.py
+++ b/lib/auxiliary/config.py
@@ -44,7 +44,7 @@ def isbrokenlink(path):
 
   try:
     os.stat(path)
-  except os.error, err:
+  except os.error as err:
     # broken link
     # "No such file or directory"
     if err.errno == errno.ENOENT:
@@ -336,7 +336,7 @@ def parse_cld_defs_file(cloud_definitions, print_message = False, \
     
                             _multiline = True
                             if _key.count("enema") :
-                                print '\n' + _key
+                                print('\n' + _key)
                         else :
                             _msg = "configuration error: variable " + _key.upper()
                             _msg += "= has to be preceded by one occurrence of "
@@ -403,22 +403,22 @@ def parse_cld_defs_file(cloud_definitions, print_message = False, \
             _msg = "\"" +  _file_name + "\" opened and parsed successfully."
 
             if print_message :
-                print _msg
+                print(_msg)
 
             return _cld_attr_lst, "\n".join(_cloud_definitions_fc)
 
-        except IOError, msg :
+        except IOError as msg :
             if _file_names.index(_file_name) == len(_file_names) - 1 :
                 _msg = "Unable to open any of the following files: "
                 _msg += ','.join(_file_names) + ':' + str(msg)
                 raise Exception(_msg)
                 exit(1)
         
-        except NetworkException, obj :
+        except NetworkException as obj :
             raise Exception(str(obj))
             exit(1)
         
-        except Exception, e :
+        except Exception as e :
             raise Exception(str(e))
             exit(1)
 
@@ -489,7 +489,7 @@ def get_my_parameters(me):
 
 @trace
 def set_my_parameters(me, parameters):
-    for key, value in parameters.iteritems() :
+    for key, value in parameters.items() :
         if key.lower().count("cloudoption") :
             continue
         try:

--- a/lib/remote/network_functions.py
+++ b/lib/remote/network_functions.py
@@ -24,9 +24,13 @@
     @author: Michael R. Hines, Marcio A. Silva
 '''
 
+import sys
 import socket
 import struct
-import urllib2
+if sys.version_info[0] < 3:
+    import urllib2
+else:
+    import urllib.request
 
 try :
     import IN
@@ -186,7 +190,7 @@ def get_syslog_port(username) :
         cbdebug(_msg)
         return _syslog_port
     
-    except Exception, e :
+    except Exception as e :
         _msg = "Unable to find default syslog port for this CloudBench host: " + _syslog_port
         cberr(_msg)
         raise NetworkException(str(_msg), 1)
@@ -237,7 +241,7 @@ def hostname2ip(hostname, raise_exception = False) :
         _msg = "Error while attempting to resolve the " + _x + " \"" + hostname + "\"."
         _msg += " Please make sure this name is resolvable either in /etc/hosts or DNS."
 
-    except Exception, e :
+    except Exception as e :
         _status = 23
         _msg = "Error while attempting to resolve the " + _x + " \"" + hostname + "\":" + str(e)
 
@@ -268,8 +272,8 @@ def get_mtu(ifname) :
     try:
         ifs = ioctl(s, SIOCGIFMTU, ifr)
         mtu = struct.unpack('<H',ifs[16:18])[0]
-    except Exception, s:
-        print 'socket ioctl call failed: {0}'.format(s)
+    except Exception as s:
+        print('socket ioctl call failed: {0}'.format(s))
         raise
  
     return mtu
@@ -282,7 +286,10 @@ def check_url(url, string_to_replace = None, string_replacement = None, tout = 3
         if len(url) :
             if string_to_replace and string_replacement :
                 _url = url.replace(string_to_replace, string_replacement.strip())
-            urllib2.urlopen(urllib2.Request(_url), timeout = tout)
+            if sys.version_info[0] < 3:
+                urllib2.urlopen(urllib2.Request(_url), timeout = tout)
+            else:
+                urllib.request.urlopen(urllib.request.Request(_url), timeout = tout)
         return True
         
     except:
@@ -348,7 +355,7 @@ class Nethashget :
                 cberr(_msg)
                 raise NetworkException(str(_msg), "1")
 
-        except socket.error, msg :
+        except socket.error as msg :
             self.socket.close()
             self.socket = None
 
@@ -377,7 +384,7 @@ class Nethashget :
             self.socket.connect((self.hostname, self.port if port is None else port))
             return True
         
-        except socket.error, msg :
+        except socket.error as msg :
             _msg = "Unable to connect to " + protocol + " port " + str(port)
             _msg += " on host " + self.hostname + ": " + str(msg)
             cbinfo(_msg)
@@ -401,7 +408,7 @@ class Nethashget :
         if reset :
             try :
                 self.connect()
-            except socket.error, msg :
+            except socket.error as msg :
                 _msg = "ERROR cannot connect to ganglia gmetad to the port "
                 _msg += self.port + " on server " + self.hostname + ": "
                 _msg += str(msg) + '.' 

--- a/lib/stores/mongodb_datastore_adapter.py
+++ b/lib/stores/mongodb_datastore_adapter.py
@@ -25,6 +25,7 @@
 '''
 
 import os
+import sys
 import pymongo
 
 from time import sleep, time
@@ -36,7 +37,7 @@ from pymongo import MongoClient
 from pymongo import errors as PymongoException
 
 def print_standalone(str) :
-    print str
+    print(str)
 
 def trace_nothing(aFunc):
     return aFunc
@@ -94,13 +95,13 @@ class MongodbMgdConn :
         '''
         try:
 
-            if tout > 0:            
-                
+            if sys.version_info[0] < 3:
+
                 _conn = MongoClient(host = self.host, port = self.port, \
                                     max_pool_size=10)
             else :
                 _conn = MongoClient(host = self.host, port = self.port, \
-                                    max_pool_size=10)
+                                    maxPoolSize=10)
 
             self.mongodb_conn = _conn
             
@@ -111,7 +112,7 @@ class MongodbMgdConn :
             cbdebug(_msg)            
             return self.mongodb_conn
 
-        except PymongoException, msg :
+        except PymongoException as msg :
             True
 
         except :
@@ -134,7 +135,7 @@ class MongodbMgdConn :
             cbdebug(_msg)            
             return self.mongodb_conn
 
-        except PymongoException, msg :
+        except PymongoException as msg :
             _msg = "Unable to establish a connection with the MongoDB "
             _msg += "server on host " + self.host + " port "
             _msg += str(self.port) + "database " + str(self.database) + ": "
@@ -158,7 +159,7 @@ class MongodbMgdConn :
                 cbdebug(_msg)
                 return self.mongodb_conn
 
-        except PymongoException, msg :
+        except PymongoException as msg :
             _msg = "Unable to terminate a connection with the MongoDB "
             _msg += "server on host " + self.host + " port "
             _msg += str(self.port) + "database " + str(self.database) + ": "
@@ -184,7 +185,7 @@ class MongodbMgdConn :
             try :
                 self.connect(self.timeout)
                 
-            except self.MetricStoreMgdConnException, obj :
+            except self.MetricStoreMgdConnException as obj :
                 raise self.MetricStoreMgdConnException(obj.msg, 2)
             
             if len(self.password) > 2 and self.password.lower() != "false" :
@@ -198,14 +199,14 @@ class MongodbMgdConn :
                     
                     self.mongodb_conn[self.database].authenticate(self.username, self.password, mechanism='MONGODB-CR')
 
-                except PymongoException, errmsg :
+                except PymongoException as errmsg :
                     _msg = "Unable to authenticate against the database \"" + self.database
                     _msg += "\":" + str(errmsg) + ". \nPlease create the user there (i.e., directly on "
                     _msg += self.host + ") using the following command:\n"                    
                     _msg += _auth_cmd
                     raise self.MetricStoreMgdConnException(_msg, 2)
     
-                except Exception, e:
+                except Exception as e:
                     _msg = "Unable to authenticate against the database \"" + self.database
                     _msg += "\":" + str(e) + ". \nPlease create the user there (i.e., directly on "
                     _msg += self.host + ") using the following command:\n"               
@@ -257,7 +258,7 @@ class MongodbMgdConn :
             self.disconnect()
             return True
 
-        except PymongoException, msg :
+        except PymongoException as msg :
             _msg = "Unable to initialize all documents on "
             _msg += "\" on collection \"" + _collection + "\": " 
             _msg += str(msg) + '.'
@@ -299,7 +300,7 @@ class MongodbMgdConn :
             self.disconnect()
             return True
 
-        except PymongoException, msg :
+        except PymongoException as msg :
             _msg = "Unable to initialize all documents on "
             _msg += "\" on collection \"" + _collection + "\": " 
             _msg += str(msg) + '.'
@@ -326,7 +327,7 @@ class MongodbMgdConn :
                 self.disconnect()
             return True
 
-        except PymongoException, msg :
+        except PymongoException as msg :
             _msg = "Unable to insert document \"" + document
             _msg += "\" on collection \"" + collection + "\": " 
             _msg += str(msg) + '.'
@@ -366,7 +367,7 @@ class MongodbMgdConn :
 
             return _results
 
-        except PymongoException, msg :
+        except PymongoException as msg :
             _msg = "Unable to retrieve documents from the collection \""
             _msg += collection + ": " 
             _msg += str(msg) + '.'
@@ -398,7 +399,7 @@ class MongodbMgdConn :
             if disconnect_finish :
                 self.disconnect()
 
-        except PymongoException, msg :
+        except PymongoException as msg :
             _msg = "Unable to update documents from the collection \""
             _msg += collection + ": " 
             _msg += str(msg) + '.'
@@ -425,7 +426,7 @@ class MongodbMgdConn :
             if disconnect_finish :
                 self.disconnect()
 
-        except PymongoException, msg :
+        except PymongoException as msg :
             _msg = "Unable to remove document from the collection \""
             _msg += collection + ": " 
             _msg += str(msg) + '.'
@@ -448,7 +449,7 @@ class MongodbMgdConn :
                 self.disconnect()
             return True
 
-        except PymongoException, msg :
+        except PymongoException as msg :
             _msg = "Unable to drop all documents from the collection \""
             _msg += collection + ": " 
             _msg += str(msg) + '.'
@@ -471,7 +472,7 @@ class MongodbMgdConn :
                 self.disconnect()
             return _matches.count()
 
-        except PymongoException, msg :
+        except PymongoException as msg :
             _msg = "Unable to count documents on the collection \""
             _msg += collection + ": " 
             _msg += str(msg) + '.'
@@ -509,7 +510,7 @@ class MongodbMgdConn :
                 self.disconnect()
             return _result
 
-        except PymongoException, msg :
+        except PymongoException as msg :
             _msg = "Unable to get reported attributes on the collection \""
             _msg += collection + ": " 
             _msg += str(msg) + '.'
@@ -534,7 +535,7 @@ class MongodbMgdConn :
 
             return _start_time, _end_time
 
-        except PymongoException, msg :
+        except PymongoException as msg :
             _msg = "Unable to get time boundaries on the collection \""
             _msg += collection + ": " 
             _msg += str(msg) + '.'
@@ -565,7 +566,7 @@ class MongodbMgdConn :
 
             return _experiment_list
 
-        except PymongoException, msg :
+        except PymongoException as msg :
             _msg = "Unable to get time boundaries on the collection \""
             _msg += collection + ": " 
             _msg += str(msg) + '.'
@@ -594,7 +595,7 @@ class MongodbMgdConn :
             
             return _output
 
-        except PymongoException, msg :
+        except PymongoException as msg :
             _msg = "Unable to get info database " + self.database + ": " 
             _msg += str(msg) + '.'
             cberr(_msg)


### PR DESCRIPTION
Only fixed the syntax so the cbtool module installed from pip can run
with python3. Everything still runs fine with Python 2.7.

After making the change and ensuring we can import the pip package in python3, I tested various CB functions (attaching to VMC, creating/stopping AIs, etc) with python2.7 and everything is still working as is.

The changes I made are compatible with python3 and python2.7 and I included a couple of version checks at the places where a breaking code change was required

Signed-off-by: Julien Desfossez <jdesfossez@digitalocean.com>