### PR TITLE
Remove dynamic API binding logic

### DIFF
--- a/lib/operations/passive_operations.py
+++ b/lib/operations/passive_operations.py
@@ -2330,54 +2330,7 @@ class PassiveObjectOperations(BaseObjectOperations) :
                     append_service(hostname, apiservice)
                         
             if not debug or len(apiservices) > 1 :
-                # The API service daemon needs to listen
-                # on an additional network interface.
-                # The API has a method called 'bind' which allows it to fork a new
-                # multi-threaded instance of itself on a new address
-                
-                from lib.api.api_service_client import APIClient, APIException
-                api = APIClient("http://" + hostname + ":" + port)
-                    
-                services = {}
-                
                 while True :
-                    clouds = api.cldlist()
-                    found = {} 
-                    for cloud in clouds :
-                        # The binded API server for the VPN address comes online later after the next sleep. It won't show up immediately, because the VPN client is forked later.
-                        if cloud["name"] not in services :
-                            attrs = api.cldshow(cloud["name"], "vpn")
-                            
-                            if attrs["start_server"].lower() != "false" :
-                                address = attrs["server_bootstrap"]
-                                result = False 
-                                msg = "Failed to register openvpn address " + address + ": "
-                                try :
-                                    result = api.register(address)
-                                    services[cloud["name"]] = address
-                                    found[cloud["name"]] = cloud
-                                    msg = "Success registering openvpn address: " + address
-                                except APIException, e :
-                                    msg += str(e)
-                                except Exception, e :
-                                    msg += str(e)
-                                finally :
-                                    if result :
-                                        cbdebug(msg)
-                                    else :
-                                        cberr(msg)
-                            else :
-                                found[cloud["name"]] = True 
-                        else :
-                            found[cloud["name"]] = True 
-                                        
-                    for cloud_name in services.keys() :
-                        address = services[cloud_name]
-                        if cloud_name not in found :
-                            cbdebug("Cloud " + cloud_name + " has disappeared. Unregistering from " + address)
-                            del services[cloud_name]
-                            api.unregister(address)
-                        
                     sleep(10)
                     
                 for apiservice in apiservices :
@@ -2386,6 +2339,8 @@ class PassiveObjectOperations(BaseObjectOperations) :
             _status = 0
 
         except Exception, e :
+            for line in traceback.format_exc().splitlines() :
+                cbwarn(line, True)
             _status = 23
             _fmsg = str(e)
 


### PR DESCRIPTION
This code is a relic from another era. We used to run multiple cloud
attachments in the same CB instance, which is still supported, but
not while the VPN is running. Just don't do that anymore.