### PR TITLE
Harden the bare metal Docker adapter

### DIFF
--- a/docker/orchestrator/Dockerfile-centos_cb_orchestrator
+++ b/docker/orchestrator/Dockerfile-centos_cb_orchestrator
@@ -279,7 +279,7 @@ RUN pip3 install --upgrade gcloud google-api-python-client
 # pygce-install-pip
 
 # pydocker-install-pip
-RUN pip3 install --upgrade docker-py wget
+RUN pip3 install --upgrade docker wget
 # pydocker-install-pip
 
 # pylxd-install-pip

--- a/kvm-qemu/base/ubuntu_commands
+++ b/kvm-qemu/base/ubuntu_commands
@@ -50,7 +50,7 @@ run-command sudo pip3 install -i https://pypi.python.org/simple/ requests==2.12
 run-command sudo pip3 install -i https://pypi.python.org/simple/ docutils 
 run-command sudo pip3 install -i https://pypi.python.org/simple/ python-daemon
 run-command sudo pip3 install -i https://pypi.python.org/simple/ --upgrade pyasn1-modules
-run-command sudo pip3 install -i https://pypi.python.org/simple/ --upgrade docker-py wget markup httplib2shim pylxd mongo beaker webob redis 
+run-command sudo pip3 install -i https://pypi.python.org/simple/ --upgrade docker wget markup httplib2shim pylxd mongo beaker webob redis 
 
 run-command curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 run-command add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"

--- a/lib/auxiliary/data_ops.py
+++ b/lib/auxiliary/data_ops.py
@@ -351,7 +351,7 @@ def value_suffix(value, in_kilobytes = False) :
         _value = int(value)
     return _value
 
-def get_boostrap_command(obj_attr_list, cloud_init = False) :
+def get_bootstrap_command(obj_attr_list, cloud_init = False) :
     '''
     TBD
     '''

--- a/lib/clouds/shared_functions.py
+++ b/lib/clouds/shared_functions.py
@@ -36,7 +36,7 @@ from uuid import uuid5, UUID, NAMESPACE_DNS
 from socket import gethostbyname
 from random import randint
 
-from lib.auxiliary.data_ops import str2dic, dic2str, value_suffix, get_boostrap_command, DataOpsException
+from lib.auxiliary.data_ops import str2dic, dic2str, value_suffix, get_bootstrap_command, DataOpsException
 from lib.auxiliary.code_instrumentation import trace, cbdebug, cberr, cbwarn, cbinfo, cbcrit
 from lib.remote.network_functions import Nethashget, hostname2ip
 from lib.stores.redis_datastore_adapter import RedisMgdConn
@@ -1043,6 +1043,9 @@ class CommonCloudFunctions:
         _detected_imageids = {}
         _undetected_imageids = {}
 
+        #cbdebug("Required list: " + str(_required_imageid_list), True)
+        #cbdebug("Registered list: " + str(registered_imageid_list), True)
+        #cbdebug("Mapped list: " + str(map_id_to_name), True)
         for _imageid in list(_required_imageid_list.keys()) :
             
             # Unfortunately we have to check image names one by one,
@@ -1051,6 +1054,7 @@ class CommonCloudFunctions:
             # times as if it were different images.
             _image_detected = False
             for _registered_imageid in registered_imageid_list :
+                #cbdebug("Comparing " + _registered_imageid + " to " + _imageid, True)
                 if str(_registered_imageid).count(_imageid) :
                     _image_detected = True
                     _detected_imageids[_imageid] = "detected"
@@ -1254,7 +1258,7 @@ packages:"""
         _bootstrap_script += _pad + "chmod 777 /var/log/cloudbench\n"
         _bootstrap_script += _pad + "\n"
         
-        _bootstrap_script += get_boostrap_command(obj_attr_list, True)
+        _bootstrap_script += get_bootstrap_command(obj_attr_list, True)
         
         _bootstrap_script += _pad + "if [[ $(cat " + obj_attr_list["remote_dir_home"] + "/cb_os_parameters.txt | grep -c \"#OSOI-" + "TEST_" + obj_attr_list["username"] + ":" + obj_attr_list["cloud_name"] + "\") -ne 0 ]]\n"
         _bootstrap_script += _pad + "then\n"

--- a/lib/operations/active_operations.py
+++ b/lib/operations/active_operations.py
@@ -32,7 +32,7 @@ from uuid import uuid5, NAMESPACE_DNS
 
 from lib.remote.process_management import ProcessManagement
 from lib.auxiliary.code_instrumentation import trace, cbdebug, cberr, cbwarn, cbinfo, cbcrit
-from lib.auxiliary.data_ops import str2dic, dic2str, get_boostrap_command, selectively_print_message, DataOpsException
+from lib.auxiliary.data_ops import str2dic, dic2str, get_bootstrap_command, selectively_print_message, DataOpsException
 from lib.auxiliary.value_generation import ValueGeneration
 from lib.stores.stores_initial_setup import StoreSetupException
 from lib.auxiliary.thread_pool import ThreadPool
@@ -2478,7 +2478,7 @@ class ActiveObjectOperations(BaseObjectOperations) :
             cbdebug(_msg)
             
             _msg = "Bootstrapping " + obj_attr_list["log_string"]  + ": creating file"
-            _msg += " cb_os_paramaters.txt in \"" + obj_attr_list["login"] 
+            _msg += " cb_os_parameters.txt in \"" + obj_attr_list["login"] 
             _msg += "\" user's home dir on IP address " 
             _msg += obj_attr_list["prov_cloud_ip"] + "..."
 
@@ -2495,7 +2495,7 @@ class ActiveObjectOperations(BaseObjectOperations) :
                 else :
                     _actual_tries = int(obj_attr_list["update_attempts"])                
                 
-                _bcmd = get_boostrap_command(obj_attr_list, self.osci)
+                _bcmd = get_bootstrap_command(obj_attr_list, cloud_init = False)
                 
                 _msg = "BOOTSTRAP: " + _bcmd
                 cbdebug(_msg)

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setuptools.setup(
           'softlayer',
           'boto',
           'apache-libcloud',
-          'pydocker',
+          'docker',
           'pylxd',
           'pykube',
           'docutils',


### PR DESCRIPTION
We've fixed a number of issues to stabilize the adapter.

1. Move to more updated/maintained version of the python docker bindings.
2. Use the object-oriented version of the bindings.
3. Stop pre-caching images on startup. Only pull the image when the corresponding benchmark is requested.
4. Remove thread safety conflicts.
5. Support private and remote repositories.
6. Provide an example of a benchmark (like mysql) using a *different* memory allocation
   in this kind of environment than when it runs in VMs.
7. Other things I cannot remember...