### PR TITLE
Fix: With netname public, use the public IP even if we have a private IP

### DIFF
--- a/lib/clouds/libcloud_common.py
+++ b/lib/clouds/libcloud_common.py
@@ -893,6 +893,8 @@ class LibcloudCmds(CommonCloudFunctions) :
             if len(node.private_ips) > 0 :
                 if obj_attr_list["run_netname"].lower() != "public" :
                     obj_attr_list["run_cloud_ip"] = node.private_ips[0]
+                elif len(node.public_ips) > 0 :
+                    obj_attr_list["run_cloud_ip"] = node.public_ips[0]
 
                 if not self.use_public_ips :
                     obj_attr_list["run_cloud_ip"] = node.private_ips[0]


### PR DESCRIPTION
In the case where netname is set to public but the cloud still assigns a
private IP, we want to be able to use the public IP.

Signed-off-by: Julien Desfossez <jdesfossez@digitalocean.com>