### PR TITLE
Support additional FIO config options within cbtool

### DIFF
--- a/scripts/fio/cb.fiojob.template
+++ b/scripts/fio/cb.fiojob.template
@@ -21,5 +21,9 @@ rw=LOAD_PROFILE
 sync=FIO_SYNC
 numjobs=LOAD_LEVEL
 group_reporting
+#thinktime=FIO_THINKTIME
+#thinktime_blocks=FIO_NUM_BLOCKS
+#rate_process=FIO_RATE_PROCESS
+#bssplit=FIO_BLKSPLIT
 #verify=FIO_VERIFY
 #verify_fatal=FIO_VERIFY_FATAL

--- a/scripts/fio/cb_run_fio.sh
+++ b/scripts/fio/cb_run_fio.sh
@@ -27,6 +27,11 @@ FIO_CREATE_ON_OPEN=$(get_my_ai_attribute_with_default fio_create_on_open 1)
 # file size to test in MB
 FIO_FILE_SIZE=$(get_my_ai_attribute_with_default fio_file_size 128M)
 
+FIO_THINKTIME=$(get_my_ai_attribute_with_default fio_thinktime none)
+FIO_NUM_BLOCKS=$(get_my_ai_attribute_with_default fio_num_blocks 0)
+FIO_RATE_PROCESS=$(get_my_ai_attribute_with_default fio_rate_process none)
+FIO_BLKSPLIT=$(get_my_ai_attribute_with_default fio_blksplit none)
+
 FIO_DATA_DIR=$(get_my_ai_attribute_with_default fio_data_dir /fiotest)
 FIO_IODEPTH=$(get_my_ai_attribute_with_default fio_iodepth 8)
 FIO_SYNC=$(get_my_ai_attribute_with_default fio_sync 0)
@@ -52,6 +57,15 @@ sed -i "s^LOAD_PROFILE^$LOAD_PROFILE^g" ~/*.fiojob
 sed -i "s^LOAD_LEVEL^$LOAD_LEVEL^g" ~/*.fiojob
 sed -i "s^FIO_FILE_SIZE^${FIO_FILE_SIZE}^g" ~/*.fiojob
 sed -i "s^FIO_INVALIDATE^${FIO_INVALIDATE}m^g" ~/*.fiojob
+
+if [[ $FIO_RATE_PROCESS != "none" ]]
+then
+    sed -i "s^#thinktime=FIO_THINKTIME^thinktime=${FIO_THINKTIME}s^g" ~/*.fiojob
+    sed -i "s^#thinktime_blocks=FIO_NUM_BLOCKS^thinktime_blocks=${FIO_NUM_BLOCKS}^g" ~/*.fiojob
+    sed -i "s^#rate_process=FIO_RATE_PROCESS^rate_process=${FIO_RATE_PROCESS}^g" ~/*.fiojob
+    sed -i "s^#bssplit=FIO_BLKSPLIT^bssplit=${FIO_BLKSPLIT}^g" ~/*.fiojob
+    sed -i "s^bs=$FIO_BS^#bs=$FIO_BS^g" ~/*.fiojob
+fi
 
 if [[ $(echo $FIO_DATA_DIR | tr '[:upper:]' '[:lower:]') != "none" ]]
 then

--- a/scripts/fio/virtual_application.txt
+++ b/scripts/fio/virtual_application.txt
@@ -33,6 +33,10 @@ FIO_START1 = cb_run_fio.sh
 
 # VApp-specific modifier parameters. Commented attributes imply default values assumed
 FIO_ENGINE = sync
+FIO_THINKTIME = none
+FIO_NUM_BLOCKS = 1000
+FIO_RATE_PROCESS = poisson
+FIO_BLKSPLIT = 4k/25:16k/25:64k/25:128k/25,4k/25:16k/25:64k/25:128k/25
 FIO_BS = 64k
 FIO_DIRECT= 1
 FIO_CREATE_ON_OPEN = 1


### PR DESCRIPTION
This adds support for some further FIO config options
within cbtool. Following FIO config params were added:

       - thinktime
       - thinktime_blocks
       - rate_process
       - bssplit

The default behavior is to not use them unless someone enable
them in the FIO based AI config.