### PR TITLE
fix MetricStoreMgdConnException issue

### DIFF
--- a/lib/operations/base_operations.py
+++ b/lib/operations/base_operations.py
@@ -43,7 +43,17 @@ from lib.remote.network_functions import Nethashget
 from lib.remote.ssh_ops import repeated_ssh
 from lib.remote.process_management import ProcessManagement
 from lib.stores.stores_initial_setup import syslog_logstore_setup, load_metricstore_adapter
-from lib.stores.common_datastore_adapter import MetricStoreMgdConnException
+
+class MetricStoreMgdConnException(Exception) :
+    '''
+    TBD
+    '''
+    def __init__(self, msg, status):
+        Exception.__init__(self)
+        self.msg = msg
+        self.status = status
+    def __str__(self):
+        return self.msg
 
 class BaseObjectOperations :
     '''

--- a/lib/stores/mysql_datastore_adapter.py
+++ b/lib/stores/mysql_datastore_adapter.py
@@ -28,7 +28,18 @@ import threading
 import mysql.connector
 
 from lib.auxiliary.code_instrumentation import trace, cbdebug, cberr, cbwarn, cbinfo, cbcrit
-from lib.stores.common_datastore_adapter import MetricStoreMgdConn, MetricStoreMgdConnException
+from lib.stores.common_datastore_adapter import MetricStoreMgdConn
+
+class MetricStoreMgdConnException(Exception) :
+    '''
+    TBD
+    '''
+    def __init__(self, msg, status):
+        Exception.__init__(self)
+        self.msg = msg
+        self.status = status
+    def __str__(self):
+        return self.msg
 
 class MysqlMgdConn(MetricStoreMgdConn) :
     @trace


### PR DESCRIPTION
We faced an issue within cb in which when the code path
was touching this user-defined exception "MetricStoreMgdConnException"
python3 complained with following msg:

"TypeError: catching classes that do not inherit from BaseException
is not allowed."

Due to this, the client API object was getting hung and the client API kept
waiting to receive something from the socket. This fixes the issue
by using local version of MetricStoreMgdConnException class and
because of that we no longer see that TypeError msg.