### PR TITLE
Vermavis/mysql adapter changes

### DIFF
--- a/lib/stores/common_datastore_adapter.py
+++ b/lib/stores/common_datastore_adapter.py
@@ -30,8 +30,6 @@ in particular the table naming scheme.
 '''
 
 class MetricStoreMgdConn :
-    catalogs = threading.local()
-
     @trace
     def __init__(self, parameters) :
         set_my_parameters(self, parameters)


### PR DESCRIPTION
There was an issue noticed related to lots of outstanding TIME_WAIT TCP
connections on the client side when using the new mysql adapter. This happens
whenever a cb thread tries to record something in the MySQL DB wherein
it tries to establish a new connection to the MySQL server endpoint leading
to outstanding TIME_WAIT connections. Eventually the TIME_WAIT connections
gets killed once the connection timeout is reached.

This patch uses a global connection approach similar to the one incorporated
in MongoDB adapter. Using this, we do not see any outstanding TIME_WAITS.