### PR TITLE
Nested improvements

### DIFF
--- a/scripts/common/cb_post_boot_container.sh
+++ b/scripts/common/cb_post_boot_container.sh
@@ -26,6 +26,8 @@ fi
 
 source ${dir}/cb_common.sh
 
+fix_ulimit
+
 post_boot_steps True
 
 exit 0

--- a/scripts/tpcc/cb_restart_mysql.sh
+++ b/scripts/tpcc/cb_restart_mysql.sh
@@ -63,6 +63,7 @@ ${SUDO_CMD} sed -i '/tmp_table_size/d' ${MYSQL_CONF_FILE}
 ${SUDO_CMD} sed -i '/table_open_cache/d' ${MYSQL_CONF_FILE}
 ${SUDO_CMD} sed -i '/innodb_buffer_pool_dump_at_shutdown/d' ${MYSQL_CONF_FILE}
 ${SUDO_CMD} sed -i '/innodb_buffer_pool_load_at_startup/d' ${MYSQL_CONF_FILE}
+${SUDO_CMD} sed -i '/max_connections/d' ${MYSQL_CONF_FILE}
 
 # Set mysql's memory cache size to be a percentage of main memory
 check_container
@@ -86,6 +87,8 @@ ${SUDO_CMD} su -c "echo 'innodb_log_file_size = ${MYSQL_INNODB_LOG_FILE_SIZE}' >
 ${SUDO_CMD} su -c "echo 'query_cache_size = ${MYSQL_QUERY_CACHE_SIZE}' >> ${MYSQL_CONF_FILE}"
 ${SUDO_CMD} su -c "echo 'tmp_table_size = ${MYSQL_TMP_TABLE_SIZE}' >> ${MYSQL_CONF_FILE}"
 ${SUDO_CMD} su -c "echo 'table_open_cache = ${MYSQL_TABLE_OPEN_CACHE}' >> ${MYSQL_CONF_FILE}"
+${SUDO_CMD} su -c "echo 'max_connections = 2000' >> ${MYSQL_CONF_FILE}"
+${SUDO_CMD} su -c "echo 'large-pages' >> ${MYSQL_CONF_FILE}"
 
 if [[ $(${SUDO_CMD} ls /etc/apparmor.d/tunables/ | grep -c alias) -ne 0 ]]
 then


### PR DESCRIPTION
1. This PR speeds up container startup a little bit in the VM by using
better rsync options when the container is deployed.
2. We also provide initial support for hugepages

We spent some time testing hugepages in CloudBench.

Here are a handful of changes that help prepare to enable it in a nested
environment (particularly with the PLM adapter).

NOTE: We don't actually configure the guest kernel here yet in
CloudBench to choose the number of hugepages as that is HIGHLY dependent
on the application, but we do put the limits in place (and an example
option in MySQL).

For it to actually take effect, one would either need to reserve the
pages or turn on THP at the guest level via CloudBench in a followup PR.