### PR TITLE
MySQL improvements

### DIFF
--- a/configs/templates/stores.txt
+++ b/configs/templates/stores.txt
@@ -67,7 +67,7 @@ TIMEOUT = $MAIN_TIMEOUT
 USAGE = private
 CONFIG_STRING = $False
 MONGODB_CONFIG_STRING = logpath--REPLSTORESWORKINGDIR/logs/mongod.log; logappend--true; fork--true; port--REPLPORT; bind**ip=0.0.0.0; dbpath--REPLSTORESWORKINGDIR
-MYSQL_CONFIG_STRING = [mysqld]; user--REPLUSER; log_error--REPLSTORESWORKINGDIR/logs/mysql.err; general_log_file--REPLSTORESWORKINGDIR/logs/mysql.log; skip_grant_tables; bind**address--0.0.0.0; socket--REPLSTORESWORKINGDIR/mysql.sock; pid**file--REPLSTORESWORKINGDIR/mysql.pid; datadir--REPLSTORESWORKINGDIR/; port--REPLPORT; daemonize--TRUE; performance-schema--TRUE; show_compatibility_56--ON;
+MYSQL_CONFIG_STRING = [mysqld]; user--REPLUSER; log_error--REPLSTORESWORKINGDIR/logs/mysql.err; general_log_file--REPLSTORESWORKINGDIR/logs/mysql.log; skip_grant_tables; bind**address--0.0.0.0; socket--REPLSTORESWORKINGDIR/mysql/mysql.sock; pid**file--REPLSTORESWORKINGDIR/mysql/mysql.pid; datadir--REPLSTORESWORKINGDIR/mysql/; port--REPLPORT; daemonize--TRUE; performance-schema--TRUE; show_compatibility_56--ON;
 
 [FILESTORE]
 KIND = rsync

--- a/exclude_list.txt
+++ b/exclude_list.txt
@@ -29,6 +29,9 @@ configs/cloud_ports.sh
 configs/mrhines
 stores/*.rdb
 stores/metrics.*
+stores/metrics
+stores/mysql
+stores/mysql/*
 stores/*.conf
 stores/logs/*
 stores/*.pid

--- a/lib/auxiliary/gui.py
+++ b/lib/auxiliary/gui.py
@@ -74,7 +74,7 @@ class Dashboard () :
         self.msci = msci
         assert(msci is not None)
         self.manage_collection = {"VM": "latest_management_VM_" + self.username, \
-                                  "HOST" : "latest_management_HOST_" + self.username }
+                                  "HOST" : "management_HOST_" + self.username }
         self.latest_os_collection = {"VM" : "latest_runtime_os_VM_" + self.username, \
                                      "HOST" : "latest_runtime_os_HOST_" + self.username } 
         self.latest_app_collection = {"VM" : "latest_runtime_app_VM_" + self.username}
@@ -253,7 +253,7 @@ class Dashboard () :
             elif _obj_type == "HOST" :
                 attrs['vms'] = self.msci.count_document(self.manage_collection["VM"], \
                             {
-                                'last_known_state' : {"$regex": "with ip assigned"}, \
+                                'last_known_state' : {"$regex": ".*with ip assigned.*"}, \
                                 'mgt_999_provisioning_request_failed' : { "$exists" : False}, \
                                 'vmc_name' : attrs['cloud_hostname'] })
                 
@@ -698,6 +698,7 @@ class GUI(object):
 #            exc_type, exc_value, exc_traceback = sys.exc_info()
             resp = "<h4>Exception:</h4>"
             for line in traceback.format_exc().splitlines() :
+                cberr(line)
                 resp += "<br>" + line
 
         if isinstance(resp, str) or isinstance(resp, str):


### PR DESCRIPTION
1. MySQL supports regex, but we were not passing through those kinds of
queries correctly. Fix that. (This makes HOST-level ganglia metrics
work, particularly for the PLM adapter).

2. MySQL's data directory was being placed in the wrong place, the same
   location as where the rsync operations occur, which was inadvertently
   sending the entire local contents of the database to the VMs for no
   reason. (This should have no effect when using a remote database, of
   course.)