### PR TITLE
Disable CloudBench use of ssh-agent

### DIFF
--- a/lib/operations/active_operations.py
+++ b/lib/operations/active_operations.py
@@ -294,6 +294,7 @@ class ActiveObjectOperations(BaseObjectOperations) :
                         _command += " -o StrictHostKeyChecking=no"
                         _command += " -o UserKnownHostsFile=/dev/null"
                         _command += " -o BatchMode=yes "                                                  
+                        _command += " -o IdentitiesOnly=yes "
                         _command += ' ' + cld_attr_lst["vm_defaults"]["jumphost_login"] 
                         _command += '@' + cld_attr_lst["vm_defaults"]["jumphost_ip"]
                         _command += " \"which nc\""
@@ -2448,7 +2449,7 @@ class ActiveObjectOperations(BaseObjectOperations) :
             else :
                 _actual_tries = int(obj_attr_list["update_attempts"])
 
-            _ssh_cmd_log = "ssh -p " + str(obj_attr_list["prov_cloud_port"]) + " -i " + obj_attr_list["identity"]
+            _ssh_cmd_log = "ssh -o IdentitiesOnly=yes -p " + str(obj_attr_list["prov_cloud_port"]) + " -i " + obj_attr_list["identity"]
             _ssh_cmd_log += ' ' + obj_attr_list["login"] + "@" + obj_attr_list["prov_cloud_ip"]
             
             if obj_attr_list["role"] == "check" :
@@ -3716,7 +3717,7 @@ class ActiveObjectOperations(BaseObjectOperations) :
                         cmd = "GDK_BACKEND=broadway BROADWAY_DISPLAY=" + str(port) + " remote-viewer " + uri
                     elif operation == "login" :
                         cmd = "GDK_BACKEND=broadway BROADWAY_DISPLAY=" + str(port) + " gnome-terminal --maximize -e \\\"bash -c 'ssh " + \
-                                "-o StrictHostKeyChecking=no -i " + obj_attr_list["identity"] + " " + \
+                                "-o IdentitiesOnly=yes -o StrictHostKeyChecking=no -i " + obj_attr_list["identity"] + " " + \
                                 obj_attr_list["login"] + "@" + obj_attr_list["cloud_ip"] + "; echo connection closed; sleep 120d'\\\""
                                 
                     cmd = "screen -d -m -S gtkCBUI_" + obj_attr_list["cloud_name"] + str(port) + " bash -c \"" + cmd + "\""

--- a/lib/operations/passive_operations.py
+++ b/lib/operations/passive_operations.py
@@ -2627,7 +2627,7 @@ class PassiveObjectOperations(BaseObjectOperations) :
                                                        cloud_name = _vm_attr_list["cloud_name"], \
                                                        priv_key = _vm_attr_list["identity"])
                         
-#                        _ssh_cmd = "ssh -i " + _vm_attr_list["identity"]
+#                        _ssh_cmd = "ssh -o IdentitiesOnly=yes -i " + _vm_attr_list["identity"]
 
 #                        if "ssh_config_file" in _vm_attr_list :
 #                            _ssh_cmd += " -F " + _vm_attr_list["ssh_config_file"]

--- a/lib/remote/process_management.py
+++ b/lib/remote/process_management.py
@@ -127,6 +127,7 @@ class ProcessManagement :
             _cmd += _connection_timeout            
             _cmd += _established_timeout
             _cmd += " -o StrictHostKeyChecking=no"
+            _cmd += " -o IdentitiesOnly=yes"
             _cmd += " -o UserKnownHostsFile=/dev/null "
             _cmd += " -o BatchMode=yes " 
             _cmd += _username
@@ -481,7 +482,7 @@ class ProcessManagement :
         _cmd = _cmd + " | grep -v grep" 
 
         if self.hostname != "127.0.0.1" and self.hostname != "localhost" :
-            _cmd = "ssh " + self.hostname + ' ' + _cmd
+            _cmd = "ssh -o IdentitiesOnly=yes " + self.hostname + ' ' + _cmd
 
         _status, _result_stdout, _result_stderr = self.run_os_command(_cmd)
 

--- a/lib/remote/ssh_ops.py
+++ b/lib/remote/ssh_ops.py
@@ -87,6 +87,7 @@ class SSHMgdConn :
                 continue
                 
             _cmd = "ssh -i " + self.priv_keys[index]
+            _cmd += " -o IdentitiesOnly=yes "
             _cmd += " -o StrictHostKeyChecking=no "
             _cmd += "-o UserKnownHostsFile=/dev/null "
             _cmd += "-l " + self.logins[index] + " "
@@ -143,7 +144,7 @@ class SSHMgdConn :
         procs = []
         
         for index in range (0, len(self.ips)) :
-            _cmd = "ssh -i " + self.priv_keys[index] + " -o StrictHostKeyChecking=no "
+            _cmd = "ssh -i " + self.priv_keys[index] + " -o StrictHostKeyChecking=no -o IdentitiesOnly=yes "
             _cmd += " -l " + self.logins[index] + " "
             _cmd += self.ips[index] + " \"" + hash_cmd + "\""
             _msg = "SSH: " + _cmd

--- a/scripts/common/cb_benchmarkstart.sh
+++ b/scripts/common/cb_benchmarkstart.sh
@@ -31,13 +31,13 @@ LOAD_DURATION=$3
 SCREEN_SESSION_NAME=s_`echo ${SCRIPT_NAME:3} | cut -d "." -f 1`d
 
 syslog_netcat "Checking if a ${SCRIPT_NAME} script instance is still running on the AI's LOAD GENERATOR at ${LOAD_GENERATOR_IP} (${LOAD_GENERATOR_ROLE} VM)"
-process_list=`ssh -i ${private_file} -o StrictHostKeyChecking=no ${LOAD_GENERATOR_IP} "ps aux | grep ${SCRIPT_NAME} | grep -v benchmarkstart | grep -v grep | wc -l"`
+process_list=`ssh -i ${private_file} -o IdentitiesOnly=yes -o StrictHostKeyChecking=no ${LOAD_GENERATOR_IP} "ps aux | grep ${SCRIPT_NAME} | grep -v benchmarkstart | grep -v grep | wc -l"`
 
 if [ x"${process_list}" == x0 ]; then
         syslog_netcat "Removing any already running *screen session* (${SCREEN_SESSION_NAME}) on the AI's LOAD GENERATOR at ${LOAD_GENERATOR_IP} (${LOAD_GENERATOR_ROLE} VM)"
-        ssh -i ${private_file} -o StrictHostKeyChecking=no ${LOAD_GENERATOR_IP} "pkill -f ${SCREEN_SESSION_NAME}"
+        ssh -i ${private_file} -o IdentitiesOnly=yes -o StrictHostKeyChecking=no ${LOAD_GENERATOR_IP} "pkill -f ${SCREEN_SESSION_NAME}"
         syslog_netcat "Starting a new benchmark run on the AI's LOAD GENERATOR ${LOAD_GENERATOR_IP} (${LOAD_GENERATOR_ROLE} VM)"
-        ssh -i ${private_file} -o StrictHostKeyChecking=no ${LOAD_GENERATOR_IP} "screen -dmLS ${SCREEN_SESSION_NAME}; sleep 2; screen -S ${SCREEN_SESSION_NAME} -p 0 -X stuff \"~/${SCRIPT_NAME} ${LOAD_LEVEL} ${LOAD_DURATION}\"$(printf \\r)"
+        ssh -i ${private_file} -o IdentitiesOnly=yes -o StrictHostKeyChecking=no ${LOAD_GENERATOR_IP} "screen -dmLS ${SCREEN_SESSION_NAME}; sleep 2; screen -S ${SCREEN_SESSION_NAME} -p 0 -X stuff \"~/${SCRIPT_NAME} ${LOAD_LEVEL} ${LOAD_DURATION}\"$(printf \\r)"
 else
         syslog_netcat "A previous ${SCRIPT_NAME} script instance is still running on the AI's LOAD GENERATOR at ${LOAD_GENERATOR_IP} (${LOAD_GENERATOR_ROLE} VM). Will try again after ${LOAD_DURATION} seconds"        
 fi

--- a/util/cbssh.sh
+++ b/util/cbssh.sh
@@ -107,7 +107,7 @@ else :
     SSH_CMD_PART2="-F $VMSSHCONF"
 fi
 
-SSH_CMD_PART4="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+SSH_CMD_PART4="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes"
 
 echo "logging in: cloudbench ID: $VMID => $VMLOGIN@$VMIP"
 


### PR DESCRIPTION
When using CloudBench in a local environment where the SSH agent is in
use, we end up using the wrong identities. Make SSH use *only* the
identities specified by CloudBench when attempting to login to
CB-managed virtual machines.