### PR TITLE
allow memory stress flexibility

### DIFF
--- a/configs/templates/internal_options.txt
+++ b/configs/templates/internal_options.txt
@@ -664,5 +664,6 @@ LINPACK = imageids:1, imageid1:ubuntu_cb_linpack
 KERNBENCH = imageids:1, imageid1:ubuntu_cb_kernbench
 LB = imageids:1, imageid1:ubuntu_cb_nullworkload
 TPCC = imageids:1, imageid1:ubuntu_cb_tpcc
+STRESS = imageids:1, imageid1:ubuntu_cb_stress
 
 [SIZE_TEMPLATES]

--- a/scripts/stress/cb_run_stress.sh
+++ b/scripts/stress/cb_run_stress.sh
@@ -21,8 +21,33 @@ source $(echo $0 | sed -e "s/\(.*\/\)*.*/\1.\//g")/cb_common.sh
 
 set_load_gen $@
    
+STRESS_RAM_PERCENTAGE=`get_my_ai_attribute_with_default stress_ram_percentage 0`
 
-CMDLINE="stress-ng --cpu ${LOAD_LEVEL}--cpu-method ${LOAD_PROFILE} --metrics-brief --perf -t ${LOAD_DURATION}"
+--vm X --vm-keep
+
+CMDLINE="stress-ng --metrics-brief --perf -t ${LOAD_DURATION}"
+if [ ${STRESS_RAM_PERCENTAGE} != 0 ] ; then
+	# Set the stress memory size to be a percentage of main memory
+	check_container
+	if [ ${IS_CONTAINER} -eq 1 ] && [ `get_my_vm_attribute model` == "pdm" ] ; then
+		size=`get_my_vm_attribute size`
+		syslog_netcat "stress is running on bare metal, will use a container size of: ${size}"
+		mb_total=$(echo $size | cut -d "-" -f 2)
+		mb=$(echo "${mb_total} * ${STRESS_RAM_PERCENTAGE} / 100" | bc)
+	else
+		syslog_netcat "stress is running in a VM."
+		# We are in a VM
+		kb=$(cat /proc/meminfo  | sed -e "s/ \+/ /g" | grep MemTotal | cut -d " " -f 2)
+		mb=$(echo "$kb / 1024 * ${STRESS_RAM_PERCENTAGE} / 100" | bc)
+	fi
+
+	syslog_netcat "Calculated memory size: ${mb} MB"
+
+	# Stress automatically splits up the bytes across all the VM workers equally
+	CMDLINE="$CMDLINE --vm ${LOAD_LEVEL} --vm-bytes ${mb}M --vm-keep"
+else
+	CMDLINE="$CMDLINE --cpu ${LOAD_LEVEL} --cpu-method ${LOAD_PROFILE}"
+fi
 
 execute_load_generator "${CMDLINE}" ${RUN_OUTPUT_FILE} ${LOAD_DURATION}
 

--- a/scripts/stress/virtual_application.txt
+++ b/scripts/stress/virtual_application.txt
@@ -32,6 +32,8 @@ DESCRIPTION +=  - LOAD_DURATION meaning: maximum length of time to run.\n
 STRESS_SETUP1 = cb_check_stress.sh
 STRESS_START1 = cb_run_stress.sh
 
+STRESS_RAM_PERCENTAGE = 0
+
 # VApp-specific modifier parameters.
 
 # Inter-Virtual Application instances (inter-AI) synchronized execution. Entirely optional


### PR DESCRIPTION
Occasionally, we want to just "fill up" all the memory of a guest VM.

This patch adds the ability to do that using a percentage.