### PR TITLE
s/async/nosync for Python 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,4 +129,4 @@ To get the most current list, start CBTOOL and type ```typelist``` on the CLI. T
 Contacts:
 
 Marcio Silva marcios@us.ibm.com
-Michael Galaxy mrhines@digitalocean.com
+Michael Galaxy mgalaxy@akamai.com

--- a/cbact
+++ b/cbact
@@ -472,7 +472,7 @@ def main(options) :
             _local_process = True
             _obj_attr_list = {}
 
-            _obj_attr_list["async"] = "true"
+            _obj_attr_list["nosync"] = "true"
 
             if options.ouuid :
                 _obj_attr_list["uuid"] = options.ouuid
@@ -588,7 +588,7 @@ def main(options) :
 
             _obj_attr_list = {}
 
-            _obj_attr_list["async"] = "true"
+            _obj_attr_list["nosync"] = "true"
 
             if _obj_type.upper() == "VM" :
                 _obj_type = "VM"
@@ -602,7 +602,7 @@ def main(options) :
 
             _obj_attr_list = {}
 
-            _obj_attr_list["async"] = "true"
+            _obj_attr_list["nosync"] = "true"
 
             if _obj_type.upper() == "VM" :
                 _obj_type = "VM"
@@ -615,7 +615,7 @@ def main(options) :
 
             _obj_attr_list = {}
 
-            _obj_attr_list["async"] = "true"
+            _obj_attr_list["nosync"] = "true"
 
             if _obj_type.upper() == "VM" :
                 _obj_type = "VM"

--- a/clients/FIOProvision.py
+++ b/clients/FIOProvision.py
@@ -144,7 +144,7 @@ try :
         else :
            _launch = _launch_rate
         logger.info("Launching : %s guests" % _launch)
-        api.appattach(_cloud_name,_workload,async=_launch)
+        api.appattach(_cloud_name,_workload, nosync=_launch)
 #----------------------- Wait for the AIs to be launched -----------------------
         while True :
             _ai_list = []

--- a/clients/ProvisionLinpack.py
+++ b/clients/ProvisionLinpack.py
@@ -141,7 +141,7 @@ try :
         else :
            _launch = _launch_rate
         logger.info("Launching : %s guests" % _launch)
-        api.appattach(_cloud_name,_workload,async=_launch)
+        api.appattach(_cloud_name,_workload,nosync=_launch)
 #----------------------- Wait for the AIs to be launched -----------------------
         while True :
             _ai_list = []

--- a/clients/async_attach_application.py
+++ b/clients/async_attach_application.py
@@ -83,7 +83,7 @@ try :
 
     api.cldalter(cloud_name, "time", "experiment_id", expid)
 
-    _tmp_app = api.appattach(cloud_name, "fio", "default", "default", "none", "none", "none", "empty=empty", "async")
+    _tmp_app = api.appattach(cloud_name, "fio", "default", "default", "none", "none", "none", "empty=empty", "nosync")
     print(str(_tmp_app))
     uuid = _tmp_app["uuid"]
 

--- a/docs/help/vmattach.txt
+++ b/docs/help/vmattach.txt
@@ -28,7 +28,7 @@ Usage: vmattach <cloud name> <role> [vmc pool] [size] [mode]
 
 	[mode] indicates the execution mode. The default execution mode is synchronous,
 		which blocks the command line execution until the operation is completed.
-		By adding the keyword "async" to the command, a new daemon is spawned, and
+		By adding the keyword "nosync" to the command, a new daemon is spawned, and
 		the attachment process occurs in the background.
 
 Examples :	
@@ -48,7 +48,7 @@ Examples :
 	VM vm_7 (B4BE1D3E-4602-5710-8A24-B245856ED297) attached. ssh-accessible at: 181.236.235.158 (cb-181.236.235.158).
 	(Cloudbench) 
 	
-	(Cloudbench) vmattach TESTCLOUD db2 async
+	(Cloudbench) vmattach TESTCLOUD db2 nosync
 	Background operation execution success.Operation "vm-attach" will be processed asynchronously, through the command "/home/cbrtuser/cloudbench/cloudbench_actuator.py --procid=TEST_cbrtuser --osp=port:49014,timeout:70,hostname:9.2.208.60,database:0,protocol:TCP,kind:redis --oop=TESTCLOUD,db2 --operation=vm-attach --cn=TESTCLOUD --uuid=642C137C-D72F-5E89-8DBA-7E1CBAFB9F21 --daemon". The process id is 26786.
 	
 	(Cloudbench) 

--- a/docs/help/vmcattach.txt
+++ b/docs/help/vmcattach.txt
@@ -24,7 +24,7 @@ Usage: vmcattach <cloud name> <vmc name> [pool] [mode]
 		 
 	[mode] indicates the execution mode. The default execution mode is synchronous,
 		which blocks the command line execution until the operation is completed.
-		By adding the keyword "async" to the command, a new daemon is spawned, and
+		By adding the keyword "nosync" to the command, a new daemon is spawned, and
 		the attachment process occurs in the background.
 
 Examples :	
@@ -41,7 +41,7 @@ Examples :
 	All VMCs successfully attached to this cloudbench experiment.
 	(Cloudbench) 
 	
-	(Cloudbench) vmattach TESTCLOUD tinyvm async
+	(Cloudbench) vmattach TESTCLOUD tinyvm nosync
 	Background operation execution success.Operation "vmc-attach" will be processed asynchronously, through the command "/home/cbrtuser/cloudbench/cloudbench_actuator.py --procid=TEST_cbrtuser --osp=port:49014,timeout:70,hostname:9.2.208.60,database:0,protocol:TCP,kind:redis --oop=TESTCLOUD,test_host2 --operation=vmc-attach --cn=TESTCLOUD --uuid=49E616FB-0431-5C36-9326-462EA5FE0678 --daemon". The process id is 24615.
 
 	(Cloudbench) 

--- a/docs/help/vmcdetach.txt
+++ b/docs/help/vmcdetach.txt
@@ -19,7 +19,7 @@ Usage: vmcdetach <cloud name> <vmc identifier> [force] [mode]
 		 
 	[mode] indicates the execution mode. The default execution mode is synchronous,
 		which blocks the command line execution until the operation is completed.
-		By adding the keyword "async" to the command, a new daemon is spawned, and
+		By adding the keyword "nosync" to the command, a new daemon is spawned, and
 		the attachment process occurs in the background.
 
 Examples :	
@@ -28,7 +28,7 @@ Examples :
 	VMC object B09F0F2B-031E-5240-8B91-34D1E0ACCF80 (named "test_host1") was sucessfully detached from this cloudbench experiment.
 	(Cloudbench) 
 	
-	(Cloudbench) vmcdetach TESTCLOUD test_host1 async
+	(Cloudbench) vmcdetach TESTCLOUD test_host1 nosync
 	Background operation execution success.Operation "vmc-detach" will be processed asynchronously, through the command "/home/cbrtuser/cloudbench/cloudbench_actuator.py --procid=TEST_cbrtuser --osp=port:49014,timeout:70,hostname:9.2.208.60,database:0,protocol:TCP,kind:redis --oop=TESTCLOUD,test_host1 --operation=vmc-detach --cn=TESTCLOUD --uuid=49E616FB-0431-5C36-9326-462EA5FE0678 --daemon". The process id is 18760.
 	
 	(Cloudbench) 

--- a/docs/help/vmdetach.txt
+++ b/docs/help/vmdetach.txt
@@ -18,7 +18,7 @@ Usage: vmdetach <cloud name> <vmc identifier> [force] [mode]
 		 
 	[mode] indicates the execution mode. The default execution mode is synchronous,
 		which blocks the command line execution until the operation is completed.
-		By adding the keyword "async" to the command, a new daemon is spawned, and
+		By adding the keyword "nosync" to the command, a new daemon is spawned, and
 		the attachment process occurs in the background.
 
 Examples :	
@@ -27,7 +27,7 @@ Examples :
 	VM object 642C137C-D72F-5E89-8DBA-7E1CBAFB9F21 (named "vm_32") was sucessfully detached from this cloudbench experiment.
 	(Cloudbench) 
 	
-	(Cloudbench) vmdetach TESTCLOUD vm_33 async
+	(Cloudbench) vmdetach TESTCLOUD vm_33 nosync
 	Background operation execution success.Operation "vm-detach" will be processed asynchronously, through the command "/home/cbrtuser/cloudbench/cloudbench_actuator.py --procid=TEST_cbrtuser --osp=port:49014,timeout:70,hostname:9.2.208.60,database:0,protocol:TCP,kind:redis --oop=TESTCLOUD,vm_33 --operation=vm-detach --cn=TESTCLOUD --uuid=B4BE1D3E-4602-5710-8A24-B245856ED297 --daemon". The process id is 30669.
 	(Cloudbench)
 	

--- a/gui_files/migrate_template.html
+++ b/gui_files/migrate_template.html
@@ -7,7 +7,7 @@
         <table>
             BOOTMIGRATE
             <tr><td>Interface:</td><td><input type='text' name='keyword4' value='default'/></td></tr>
-            <tr><td>Mode:</td><td><input type='text' name='keyword5' value='async'/></td></tr>
+            <tr><td>Mode:</td><td><input type='text' name='keyword5' value='nosync'/></td></tr>
             <tr><td>
             &nbsp;<button type="submit" class="btn btn-primary">
             <i class="icon-share-alt icon-white"></i>&nbsp;Migrate</button>

--- a/gui_files/protect_template.html
+++ b/gui_files/protect_template.html
@@ -7,7 +7,7 @@
         <table>
             BOOTPROTECT
             <tr><td>Interface:</td><td><input type='text' name='keyword4' value='default'/></td></tr>
-            <tr><td>Mode:</td><td><input type='text' name='keyword5' value='async'/></td></tr>
+            <tr><td>Mode:</td><td><input type='text' name='keyword5' value='nosync'/></td></tr>
             <tr><td>
             &nbsp;<button type="submit" class="btn btn-primary">
             <i class="icon-star icon-white"></i>&nbsp;Protect</button>

--- a/gui_files/wizard_template.html
+++ b/gui_files/wizard_template.html
@@ -185,7 +185,7 @@
 		
 		var cld_attr_list = (function () { 
 			var json  = null;
-			$.ajax({ 'global': false, 'async' : false, 'url': bootdest + "/wizard_options", 'dataType': "json", 'success': function (cld_attr_list) { 
+			$.ajax({ 'global': false, 'nosync' : false, 'url': bootdest + "/wizard_options", 'dataType': "json", 'success': function (cld_attr_list) { 
 			   repopulate_options(cld_attr_list);
 			   json = cld_attr_list;
 			} });

--- a/lib/api/api_service.py
+++ b/lib/api/api_service.py
@@ -267,134 +267,134 @@ class API():
     def vmresize(self, cloud_name, identifier, resource, value):
         return self.active.vmresize({}, cloud_name + ' ' + identifier + ' ' + resource + "=" + str(value), "vm-resize")[2]
     
-    def appresume(self, cloud_name, identifier, firs = "none", async = False):
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + " attached resume" + ' ' + firs + (' ' + async), "ai-runstate")[2]
+    def appresume(self, cloud_name, identifier, firs = "none", nosync = False):
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + " attached resume" + ' ' + firs + (' ' + nosync), "ai-runstate")[2]
         else :
             return self.active.airunstate({}, cloud_name + ' ' + identifier + " attached resume" + ' ' + firs, "ai-runstate")[2]
 
-    def apprestore(self, cloud_name, identifier, async = False):
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + " attached restore" + (' ' + async), "ai-runstate")[2]
+    def apprestore(self, cloud_name, identifier, nosync = False):
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + " attached restore" + (' ' + nosync), "ai-runstate")[2]
         else :
             return self.active.airunstate({}, cloud_name + ' ' + identifier + " attached restore", "ai-runstate")[2]
         
-    def appcapture(self, cloud_name, identifier, vmcrs = "none",  async = False):
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + vmcrs + (' ' + async), "ai-capture")[2]
+    def appcapture(self, cloud_name, identifier, vmcrs = "none",  nosync = False):
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + vmcrs + (' ' + nosync), "ai-capture")[2]
         else :
             return self.active.aicapture({}, cloud_name + ' ' + identifier + ' ' + vmcrs, "ai-capture")[2]
         
-    def vmcapture(self, cloud_name, identifier, captured_image_name = "auto", vmcrs = "none", async = False):
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + captured_image_name + ' ' + vmcrs + (' ' + async), "vm-capture")[2]
+    def vmcapture(self, cloud_name, identifier, captured_image_name = "auto", vmcrs = "none", nosync = False):
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + captured_image_name + ' ' + vmcrs + (' ' + nosync), "vm-capture")[2]
         else :
             return self.active.vmcapture({}, cloud_name + ' ' + identifier + ' ' + captured_image_name + ' ' + vmcrs, "vm-capture")[2]
         
-    def vmmigrate(self, cloud_name, identifier, destination, protocol = "tcp", interface = "default", async = False):
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + destination + ' ' + protocol + ' ' + interface + (' ' + async), "vm-migrate")[2]
+    def vmmigrate(self, cloud_name, identifier, destination, protocol = "tcp", interface = "default", nosync = False):
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + destination + ' ' + protocol + ' ' + interface + (' ' + nosync), "vm-migrate")[2]
         else :
             return self.active.migrate({}, cloud_name + ' ' + identifier + ' ' + destination + ' ' + protocol + ' ' + interface, "vm-migrate")[2]
     
-    def vmprotect(self, cloud_name, identifier, destination, protocol = "tcp", interface = "default", async = False):
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + destination + ' ' + protocol + ' ' + interface + (' ' + async), "vm-protect")[2]
+    def vmprotect(self, cloud_name, identifier, destination, protocol = "tcp", interface = "default", nosync = False):
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + destination + ' ' + protocol + ' ' + interface + (' ' + nosync), "vm-protect")[2]
         else :
             return self.active.migrate({}, cloud_name + ' ' + identifier + ' ' + destination + ' ' + protocol + ' ' + interface, "vm-protect")[2]
         
-    def vmlogin(self, cloud_name, identifier, async = False):
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + (' ' + async), "vm-login")[2]
+    def vmlogin(self, cloud_name, identifier, nosync = False):
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + (' ' + nosync), "vm-login")[2]
         else :
             return self.active.gtk({}, cloud_name + ' ' + identifier, "vm-login")[2]
         
-    def vmdisplay(self, cloud_name, identifier, async = False):
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + (' ' + async), "vm-display")[2]
+    def vmdisplay(self, cloud_name, identifier, nosync = False):
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + (' ' + nosync), "vm-display")[2]
         else :
             return self.active.gtk({}, cloud_name + ' ' + identifier, "vm-display")[2]
         
-    def hostfail(self, cloud_name, identifier, fault, firs = "none", async = False):
+    def hostfail(self, cloud_name, identifier, fault, firs = "none", nosync = False):
         parameters = cloud_name + ' ' + identifier + ' ' + fault + ' ' + firs
-        if async and str(async).count("async") :
-            return self.active.background_execute(parameters + (' ' + async), "host-fail")[2]
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(parameters + (' ' + nosync), "host-fail")[2]
         else :
             return self.active.hostfail_repair({}, parameters, "host-fail")[2]
         
-    def hostrepair(self, cloud_name, identifier, fault = "auto", firs = "none", async = False):
+    def hostrepair(self, cloud_name, identifier, fault = "auto", firs = "none", nosync = False):
         parameters = cloud_name + ' ' + identifier + ' ' + fault + ' ' + firs
-        if async and str(async).count("async") :
-            return self.active.background_execute(parameters + (' ' + async), "host-repair")[2]
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(parameters + (' ' + nosync), "host-repair")[2]
         else :
             return self.active.hostfail_repair({}, parameters, "host-repair")[2]
         
-    def appresize(self, cloud_name, identifier, role, delta, async = False):
+    def appresize(self, cloud_name, identifier, role, delta, nosync = False):
         parameters = cloud_name + ' ' + identifier + ' ' + role + ' ' + delta
-        if async and str(async).count("async") :
-            return self.active.background_execute(parameters + (' ' + async), "ai-resize")[2]
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(parameters + (' ' + nosync), "ai-resize")[2]
         else :
             return self.active.airesize({}, parameters, "ai-resize")[2]
     
-    def appsave(self, cloud_name, identifier, firs = "none", async = False):
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + " save" + ' ' + firs + (' ' + async), "ai-runstate")[2]
+    def appsave(self, cloud_name, identifier, firs = "none", nosync = False):
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + " save" + ' ' + firs + (' ' + nosync), "ai-runstate")[2]
         else :
             return self.active.airunstate({}, cloud_name + ' ' + identifier + " save" + ' ' + firs, "ai-runstate")[2]
         
-    def vmrunstate(self, cloud_name, identifier, runstate, command = "unknown", firs = "none", async = False):
+    def vmrunstate(self, cloud_name, identifier, runstate, command = "unknown", firs = "none", nosync = False):
         parameters = cloud_name + ' ' + identifier + ' ' + runstate + ' ' + command + ' ' + firs
-        if async and str(async).count("async") :
-            return self.active.background_execute(parameters + (' ' + async), "vm-runstate")[2]
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(parameters + (' ' + nosync), "vm-runstate")[2]
         else :
             return self.active.vmrunstate({}, parameters, "vm-runstate")[2]
 
-    def apprunstate(self, cloud_name, identifier, runstate, command = "unknown", firs = "none", async = False):
+    def apprunstate(self, cloud_name, identifier, runstate, command = "unknown", firs = "none", nosync = False):
         parameters = cloud_name + ' ' + identifier + ' ' + runstate + ' ' + command + ' ' + firs
-        if async and str(async).count("async") :
-            return self.active.background_execute(parameters + (' ' + async), "ai-runstate")[2]
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(parameters + (' ' + nosync), "ai-runstate")[2]
         else :
             return self.active.airunstate({}, parameters, "ai-runstate")[2]
         
-    def appfail(self, cloud_name, identifier, firs = "none", async = False):
-        return self.appsuspend(cloud_name, identifier, firs, async)
+    def appfail(self, cloud_name, identifier, firs = "none", nosync = False):
+        return self.appsuspend(cloud_name, identifier, firs, nosync)
     
-    def apprepair(self, cloud_name, identifier, firs = "none", async = False):
-        return self.appresume(cloud_name, identifier, firs, async)
+    def apprepair(self, cloud_name, identifier, firs = "none", nosync = False):
+        return self.appresume(cloud_name, identifier, firs, nosync)
     
-    def appsuspend(self, cloud_name, identifier, firs = "none", async = False):
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + " fail" + ' ' + firs + (' ' + async), "ai-runstate")[2]
+    def appsuspend(self, cloud_name, identifier, firs = "none", nosync = False):
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + " fail" + ' ' + firs + (' ' + nosync), "ai-runstate")[2]
         else :
             return self.active.airunstate({}, cloud_name + ' ' + identifier + " fail" + ' ' + firs, "ai-runstate")[2]
     
-    def vmrestore(self, cloud_name, identifier, firs = "none", async = False):
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + " attached restore" + ' ' + firs (' ' + async), "vm-runstate")[2]
+    def vmrestore(self, cloud_name, identifier, firs = "none", nosync = False):
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + " attached restore" + ' ' + firs (' ' + nosync), "vm-runstate")[2]
         else :
             return self.active.vmrunstate({}, cloud_name + ' ' + identifier + " attached restore" + ' ' + firs, "vm-runstate")[2]
     
-    def vmsave(self, cloud_name, identifier, firs = "none", async = False):
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + " save" + ' ' + firs + (' ' + async), "vm-runstate")[2]
+    def vmsave(self, cloud_name, identifier, firs = "none", nosync = False):
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + " save" + ' ' + firs + (' ' + nosync), "vm-runstate")[2]
         else :
             return self.active.vmrunstate({}, cloud_name + ' ' + identifier + " save" + ' ' + firs, "vm-runstate")[2]
     
-    def vmresume(self, cloud_name, identifier, firs = "none", async = False):
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + " attached resume" + ' ' + firs +(' ' + async), "vm-runstate")[2]
+    def vmresume(self, cloud_name, identifier, firs = "none", nosync = False):
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + " attached resume" + ' ' + firs +(' ' + nosync), "vm-runstate")[2]
         else :
             return self.active.vmrunstate({}, cloud_name + ' ' + identifier + " attached resume" + ' ' + firs, "vm-runstate")[2]
         
-    def vmfail(self, cloud_name, identifier, firs = "none", async = False):
-        return self.vmsuspend(cloud_name, identifier, firs, async)
+    def vmfail(self, cloud_name, identifier, firs = "none", nosync = False):
+        return self.vmsuspend(cloud_name, identifier, firs, nosync)
     
-    def vmrepair(self, cloud_name, identifier, firs = "none", async = False):
-        return self.vmresume(cloud_name, identifier, firs, async)
+    def vmrepair(self, cloud_name, identifier, firs = "none", nosync = False):
+        return self.vmresume(cloud_name, identifier, firs, nosync)
     
-    def vmsuspend(self, cloud_name, identifier, firs = "none", async = False):
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + " fail" + ' ' + firs + (' ' + async), "vm-runstate")[2]
+    def vmsuspend(self, cloud_name, identifier, firs = "none", nosync = False):
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + " fail" + ' ' + firs + (' ' + nosync), "vm-runstate")[2]
         else :
             return self.active.vmrunstate({}, cloud_name + ' ' + identifier + " fail" + ' ' + firs, "vm-runstate")[2]
         
@@ -440,42 +440,42 @@ class API():
     def firsalter(self, cloud_name, identifier, attribute, value):
         return self.passive.alter_object({}, cloud_name + ' ' + identifier + ' ' + attribute + "=" + str(value), "firs-alter")[2]
     
-    def vmcattach(self, cloud_name, identifier, temp_attr_list = "empty=empty", async = False) :
-        if async and str(async).count("async") :
+    def vmcattach(self, cloud_name, identifier, temp_attr_list = "empty=empty", nosync = False) :
+        if nosync and str(nosync).count("nosync") :
             if identifier == "all" :
-                return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + temp_attr_list + (' ' + async), "vmc-attachall")[2]
+                return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + temp_attr_list + (' ' + nosync), "vmc-attachall")[2]
             else :
-                return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + temp_attr_list + (' ' + async), "vmc-attach")[2]
+                return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + temp_attr_list + (' ' + nosync), "vmc-attach")[2]
         else :
             if identifier == "all" :
                 return self.active.vmcattachall({}, cloud_name + ' ' + identifier + ' ' + temp_attr_list, "vmc-attachall")[2]
             else :
                 return self.active.objattach({}, cloud_name + ' ' + identifier + ' ' + temp_attr_list, "vmc-attach")[2]
     
-    def vmcrsattach(self, cloud_name, identifier, scope = '', max_simultaneous_cap_reqs = '', max_total_cap_reqs = '', ivmcat = '', min_cap_age = '', temp_attr_list = "empty=empty", async = False):
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + scope + ' ' + max_simultaneous_cap_reqs + ' ' +  max_total_cap_reqs + ' ' + ivmcat + ' ' + min_cap_age + ' ' + temp_attr_list + (' ' + async), "vmcrs-attach")[2]
+    def vmcrsattach(self, cloud_name, identifier, scope = '', max_simultaneous_cap_reqs = '', max_total_cap_reqs = '', ivmcat = '', min_cap_age = '', temp_attr_list = "empty=empty", nosync = False):
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + scope + ' ' + max_simultaneous_cap_reqs + ' ' +  max_total_cap_reqs + ' ' + ivmcat + ' ' + min_cap_age + ' ' + temp_attr_list + (' ' + nosync), "vmcrs-attach")[2]
         else :
             return self.active.objattach({}, cloud_name + ' ' + identifier + ' ' + scope + ' ' + max_simultaneous_cap_reqs + ' ' + max_total_cap_reqs + ' ' + ivmcat + ' ' + min_cap_age + ' ' + temp_attr_list, "vmcrs-attach")[2]
 
-    def firsattach(self, cloud_name, identifier, scope = '', max_simultaenous_faults = '', max_total_faults = '', ifat = '', min_fault_age = '', ftl = '', temp_attr_list = "empty=empty", async = False):
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + scope + ' ' + max_simultaenous_faults + ' ' + max_total_faults + ' ' + ifat + ' ' + min_fault_age + ' ' + ftl + ' ' + temp_attr_list + (' ' + async), "firs-attach")[2]
+    def firsattach(self, cloud_name, identifier, scope = '', max_simultaenous_faults = '', max_total_faults = '', ifat = '', min_fault_age = '', ftl = '', temp_attr_list = "empty=empty", nosync = False):
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + scope + ' ' + max_simultaenous_faults + ' ' + max_total_faults + ' ' + ifat + ' ' + min_fault_age + ' ' + ftl + ' ' + temp_attr_list + (' ' + nosync), "firs-attach")[2]
         else :
             return self.active.objattach({}, cloud_name + ' ' + identifier + ' ' + scope + ' ' + max_simultaenous_faults + ' ' + max_total_faults + ' ' + ifat + ' ' + min_fault_age + ' ' + ftl + ' ' + temp_attr_list, "firs-attach")[2]
     
-    def appattach(self, cloud_name, gtype, load_level = "default", load_duration = "default", lifetime = "none", aidrs = "none", pause_step = "none", temp_attr_list = "empty=empty", async = False):
+    def appattach(self, cloud_name, gtype, load_level = "default", load_duration = "default", lifetime = "none", aidrs = "none", pause_step = "none", temp_attr_list = "empty=empty", nosync = False):
         parameters = cloud_name + ' ' + gtype + ' ' + str(load_level) + ' ' + str(load_duration) + ' ' + str(lifetime) + ' ' + aidrs + ' ' + pause_step + ' ' + temp_attr_list
 
-        if async :
-            async=str(async)            
-            async=async.replace("async",'')
-            async=async.replace('=','')            
+        if nosync :
+            nosync=str(nosync)            
+            nosync=nosync.replace("nosync",'')
+            nosync=nosync.replace('=','')            
 
-            if str(async.split(':')[0]).isdigit() :
-                _res = self.active.background_execute(parameters + (" async=" + str(async)), "ai-attach")[2]
+            if str(nosync.split(':')[0]).isdigit() :
+                _res = self.active.background_execute(parameters + (" nosync=" + str(nosync)), "ai-attach")[2]
             else :
-                _res = self.active.background_execute(parameters + (" async"), "ai-attach")[2]
+                _res = self.active.background_execute(parameters + (" nosync"), "ai-attach")[2]
             # This is hacky, but in order for an asynchronous attach to appear, introduce a delay between when the attach starts
             # and when a user can safely issue `applist pending`, in order for the pending object to actually show up.
             # We need a better fix for this later to ensure that the pending object is registered before the API command returns.
@@ -490,24 +490,24 @@ class API():
     def apprun(self, cloud_name, uuid) :
         return self.apprunstate(cloud_name, uuid, "attached", "run")
     
-    def appdrsattach(self, cloud_name, pattern, temp_attr_list = "empty=empty", async = False):
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + pattern + ' ' + temp_attr_list + (' ' + async), "aidrs-attach")[2]
+    def appdrsattach(self, cloud_name, pattern, temp_attr_list = "empty=empty", nosync = False):
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + pattern + ' ' + temp_attr_list + (' ' + nosync), "aidrs-attach")[2]
         else :
             return self.active.objattach({}, cloud_name + ' ' + pattern + ' ' + temp_attr_list, "aidrs-attach")[2]
 
-    def vmattach(self, cloud_name, role, vm_location = "auto", meta_tags = "empty", size = "default", pause_step = "none", temp_attr_list = "empty=empty", async = False):
+    def vmattach(self, cloud_name, role, vm_location = "auto", meta_tags = "empty", size = "default", pause_step = "none", temp_attr_list = "empty=empty", nosync = False):
         parameters = cloud_name + ' ' + role + ' ' + vm_location + ' ' + meta_tags + ' ' + size + ' ' + pause_step + ' ' + temp_attr_list
 
-        if async :
-            async=str(async)
-            async=async.replace("async",'')
-            async=async.replace('=','')            
+        if nosync :
+            nosync=str(nosync)
+            nosync=nosync.replace("nosync",'')
+            nosync=nosync.replace('=','')            
 
-            if str(async.split(':')[0]).isdigit() :
-                return self.active.background_execute(parameters + (" async=" + str(async)), "vm-attach")[2]
+            if str(nosync.split(':')[0]).isdigit() :
+                return self.active.background_execute(parameters + (" nosync=" + str(nosync)), "vm-attach")[2]
             else :
-                return self.active.background_execute(parameters + (" async"), "vm-attach")[2]
+                return self.active.background_execute(parameters + (" nosync"), "vm-attach")[2]
         else :
             return self.active.objattach({}, parameters, "vm-attach")[2]
         
@@ -517,17 +517,17 @@ class API():
     def vmrun(self, cloud_name, uuid):
         return self.vmrunstate(cloud_name, uuid, "attached", "run")
     
-    def vmdetach(self, cloud_name, identifier, force = False, async = False):
+    def vmdetach(self, cloud_name, identifier, force = False, nosync = False):
         force = str(force).lower() if force else "false"
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + force + (' ' + async), "vm-detach")[2]
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + force + (' ' + nosync), "vm-detach")[2]
         else :
             return self.active.objdetach({}, cloud_name + ' ' + identifier + ' ' + force, "vm-detach")[2]
     
-    def vmcdetach(self, cloud_name, identifier, force = False, async = False):
+    def vmcdetach(self, cloud_name, identifier, force = False, nosync = False):
         force = str(force).lower() if force else "false"
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + force + (' ' + async), "vmc-detach")[2]
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + force + (' ' + nosync), "vmc-detach")[2]
         else :
             return self.active.objdetach({}, cloud_name + ' ' + identifier + ' ' + force, "vmc-detach")[2]
         
@@ -538,31 +538,31 @@ class API():
         force = str(force).lower() if force else "false"
         return self.active.imgdelete({}, cloud_name + ' ' + identifier + ' ' + vmc + ' ' + force, "img-delete")[2]
     
-    def vmcrsdetach(self, cloud_name, identifier, force = False, async = False):
+    def vmcrsdetach(self, cloud_name, identifier, force = False, nosync = False):
         force = str(force).lower() if force else "false"
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + force + (' ' + async), "vmcrs-detach")[2]
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + force + (' ' + nosync), "vmcrs-detach")[2]
         else :
             return self.active.objdetach({}, cloud_name + ' ' + identifier + ' ' + force, "vmcrs-detach")[2]
 
-    def firsdetach(self, cloud_name, identifier, force = False, async = False):
+    def firsdetach(self, cloud_name, identifier, force = False, nosync = False):
         force = str(force).lower() if force else "false"
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + force + (' ' + async), "firs-detach")[2]
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + force + (' ' + nosync), "firs-detach")[2]
         else :
             return self.active.objdetach({}, cloud_name + ' ' + identifier + ' ' + force, "vmcrs-detach")[2]
     
-    def appdetach(self, cloud_name, identifier, force = False, async = False):
+    def appdetach(self, cloud_name, identifier, force = False, nosync = False):
         force = str(force).lower() if force else "false"
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + force + (' ' + async), "ai-detach")[2]
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + force + (' ' + nosync), "ai-detach")[2]
         else :
             return self.active.objdetach({}, cloud_name + ' ' + identifier + ' ' + force, "ai-detach")[2]
     
-    def appdrsdetach(self, cloud_name, identifier, force = False, async = False):
+    def appdrsdetach(self, cloud_name, identifier, force = False, nosync = False):
         force = str(force).lower() if force else "false"
-        if async and str(async).count("async") :
-            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + force + (' ' + async), "aidrs-detach")[2]
+        if nosync and str(nosync).count("nosync") :
+            return self.active.background_execute(cloud_name + ' ' + identifier + ' ' + force + (' ' + nosync), "aidrs-detach")[2]
         else :
             return self.active.objdetach({}, cloud_name + ' ' + identifier + ' ' + force, "aidrs-detach")[2]
     

--- a/lib/auxiliary/cli.py
+++ b/lib/auxiliary/cli.py
@@ -232,7 +232,7 @@ class CBCLI(Cmd) :
                 for x in range(1, diff) :
                     doc += "<" + spec[x] + "> "
                 for x in range(diff, num_spec) :
-                    if spec[x].lower() == "async" :
+                    if spec[x].lower() == "nosync" :
                         doc += "[mode] "
                         continue
                     doc += "[" + spec[x] + " = " + str(defaults[x - diff]) + "] "
@@ -306,18 +306,18 @@ class CBCLI(Cmd) :
                 temp_parameters = temp_parameters + list(args)[1:]
                 
             '''
-            The 'async' and other '=' keywords/options are special, because we 
+            The 'nosync' and other '=' keywords/options are special, because we 
             are allowing them to liberally float around the command line without
             being properly positioned by the user.
             
-            The API requires that 'async' and tkv be a keyword arguments,
+            The API requires that 'nosync' and tkv be a keyword arguments,
             and requires the components of the '=' sign to be splitup.
             '''
 
             parameters = []
             for param in temp_parameters :
-                if param.count("async") :
-                    kwargs["async"] = param
+                if param.count("nosync") or param.count("async") :
+                    kwargs["nosync"] = param
                     continue
 
                 if name.count("attach") :

--- a/lib/auxiliary/dependencies.py
+++ b/lib/auxiliary/dependencies.py
@@ -24,6 +24,7 @@
     @author: Marcio A. Silva, Michael R. Galaxy
 '''
 from sys import path
+import sys
 import os
 import re
 import platform
@@ -37,6 +38,18 @@ from lib.remote.process_management import ProcessManagement
 from lib.auxiliary.data_ops import cmp
 from lib.auxiliary.code_instrumentation import  VerbosityFilter, MsgFilter, cbdebug, cberr, cbwarn, cbinfo, cbcrit
 from lib.remote.network_functions import check_url
+
+try:
+    import distro
+except ModuleNotFoundError as e:
+    if sys.version_info.major > 2 and sys.version_info.minor >= 7:
+        _msg = (
+            "Python version 3.7 and higher require `distro` package to be installed. "
+            "Version: %s" % platform.python_version()
+        )
+        cberr(_msg)
+        raise e
+    pass
 
 def deps_file_parser(depsdict, username, options, hostname, process_manager = False) :
     '''
@@ -274,7 +287,13 @@ def get_linux_distro() :
     '''
     TBD
     '''
-    _linux_distro_kind, _linux_distro_ver, _linux_distro_name = platform.linux_distribution()
+    try:
+        _linux_distro_kind, _linux_distro_ver, _linux_distro_name = platform.linux_distribution()
+    except AttributeError:
+        _linux_distro_kind = distro.name()
+        _linux_distro_ver = distro.version()
+        _linux_distro_name = distro.id()
+
     if _linux_distro_kind.count("Red Hat") :
         _linux_distro_kind = "rhel"
     elif _linux_distro_kind.count("Scientific Linux") :

--- a/lib/auxiliary/gui.py
+++ b/lib/auxiliary/gui.py
@@ -748,7 +748,7 @@ class GUI(object):
     
                 if not link  :
                     if init_pending :
-                        output += "<a class='btn btn-mini btn-info' href='BOOTDEST/provision?object=" + active + "&operation=runstate&keywords=4&keyword1=" + obj["uuid"] + "&keyword2=attached&keyword3=run&keyword4=async'><i class='icon-play icon-white'></i>&nbsp;" + obj["name"] + "</a>&nbsp;&nbsp;"
+                        output += "<a class='btn btn-mini btn-info' href='BOOTDEST/provision?object=" + active + "&operation=runstate&keywords=4&keyword1=" + obj["uuid"] + "&keyword2=attached&keyword3=run&keyword4=nosync'><i class='icon-play icon-white'></i>&nbsp;" + obj["name"] + "</a>&nbsp;&nbsp;"
                     if "order" in obj :
                         order = datetime.utcfromtimestamp(int(obj["order"].split(".")[0])).strftime('%m/%d %H:%M')
                     act = ((("[" + order + "] ")) if "order" in obj else "") + obj["tracking"] if "tracking" in obj else None
@@ -846,7 +846,7 @@ class GUI(object):
                                                                                  ["execute_all_vms_booted", "Execute script at the beginning of step 5 (Application Start)"]
                                                                                  ] } ,
                               "keyword6" : { "label" : "Temporary Attributes", "values" : "" } ,
-                              "keyword7" : { "label" : "Mode", "values" : "async" }
+                              "keyword7" : { "label" : "Mode", "values" : "nosync" }
                            },
                     "app" : { 
                               "keyword1" : { "label" : "Type", "values" : [x.strip() for x in self.api.typelist(session['cloud_name'])] } ,
@@ -863,12 +863,12 @@ class GUI(object):
                                                                                  ["execute_all_vms_booted", "Execute script at the beginning of step 5 (Application Start)"],
                                                                                  ] } ,
                               "keyword7" : { "label" : "Temporary Attributes", "values" : "" } ,
-                              "keyword8" : { "label" : "Mode", "values" : "async" } ,
+                              "keyword8" : { "label" : "Mode", "values" : "nosync" } ,
                             },
                     "vmc" : { 
                              "keyword1" : { "label" : "Name", "values" : "" } ,
                              "keyword2" : { "label" : "Temporary Attributes", "values" : "" },
-                             "keyword3" : { "label" : "Mode", "values" : "async" },
+                             "keyword3" : { "label" : "Mode", "values" : "nosync" },
                              }, 
                     "appdrs" : { "keyword1" : { "label" : "Pattern", "values" : [x.strip() for x in self.api.patternlist(session['cloud_name'])] },
                                 "keyword2" : { "label" : "Temporary Attributes", "values" : "" }
@@ -911,9 +911,9 @@ class GUI(object):
                         if cloud_name == requested_cloud_name :
                             for command in available_clouds[cloud_name] :
                                 kwargs = {}
-                                if command.count("async") :
-                                    kwargs["async"] = True
-                                    command.replace("async", "")
+                                if command.count("nosync") :
+                                    kwargs["nosync"] = True
+                                    command.replace("nosync", "")
                                     
                                 parts = command.split()
                                 
@@ -936,8 +936,8 @@ class GUI(object):
                                 if fixed[0] == "vmcattach" and fixed[2] == "all" :
                                     if len(fixed) < 2 :
                                         return self.bootstrap(req, self.heromsg + "\n<h4>Malformed command in your STARTUP_COMMAND_ LIST in your config file: " + command + "</h4></div>", error = True)
-                                    if not command.count("async") :
-                                        kwargs["async"] = "async"
+                                    if not command.count("nosync") :
+                                        kwargs["nosync"] = "nosync"
                                 if fixed[0] == "cldattach" :
                                     if len(fixed) < 3 :
                                         return self.bootstrap(req, self.heromsg + "\n<h4>Malformed command in your STARTUP_COMMAND_ LIST in your config file: " + command + "</h4></div>", error = True)
@@ -1416,7 +1416,7 @@ class GUI(object):
                     <p/>
                 """
                 output += "<a class='btn btn-danger' style='padding: 3px' href='BOOTDEST/provision?object=" + req.active \
-                    + "&operation=detach&keywords=3&keyword1=all&keyword2=true&keyword3=async'><i class='icon-trash icon-white'></i>&nbsp;Detach All</a>"
+                    + "&operation=detach&keywords=3&keyword1=all&keyword2=true&keyword3=nosync'><i class='icon-trash icon-white'></i>&nbsp;Detach All</a>"
                 
             output += """
                 <p/>
@@ -1546,7 +1546,7 @@ class GUI(object):
                 if required != "any" and attrs["state"] != required  :
                     continue
                     
-                keywords["keyword" + str(len(keywords) + 1)] = "async" 
+                keywords["keyword" + str(len(keywords) + 1)] = "nosync" 
                 
                 output += "&nbsp;&nbsp;<a Class='btn btn-danger btn-small' href='BOOTDEST/provision?object=" + req.active
                 output += "&operation=" + operation

--- a/lib/clouds/shared_functions.py
+++ b/lib/clouds/shared_functions.py
@@ -194,7 +194,7 @@ class CommonCloudFunctions:
 
             _abort, _x_fmsg = self.pending_cloud_decide_abortion(obj_attr_list, "instance creation")
 
-            if "async" not in obj_attr_list or str(obj_attr_list["async"]).lower() == "false" :
+            if "nosync" not in obj_attr_list or str(obj_attr_list["nosync"]).lower() == "false" :
                 if threading.current_thread().abort :
                     _msg = obj_attr_list["log_string"] + " Create Aborting..."
                     _status = 123
@@ -387,7 +387,7 @@ class CommonCloudFunctions:
 
                 _abort, _x_fmsg = self.pending_cloud_decide_abortion(obj_attr_list, "instance boot")
 
-                if "async" not in obj_attr_list or str(obj_attr_list["async"]).lower() == "false" :
+                if "nosync" not in obj_attr_list or str(obj_attr_list["nosync"]).lower() == "false" :
                     if threading.current_thread().abort :
                         _msg = "VM Create Aborting..."
                         _status = 123

--- a/lib/operations/active_operations.py
+++ b/lib/operations/active_operations.py
@@ -1976,7 +1976,7 @@ class ActiveObjectOperations(BaseObjectOperations) :
                         _staging_parameters += obj_attr_list["size"] + ' '
                         _staging_parameters += str(_staging) + ' ' 
                         _staging_parameters += obj_attr_list["temp_attr_list"] 
-                        _staging_parameters += " async"
+                        _staging_parameters += " nosync"
                                               
                         _tmp_result = self.pause_vm(obj_attr_list, \
                                                     _sub_channel, \
@@ -1991,7 +1991,7 @@ class ActiveObjectOperations(BaseObjectOperations) :
                         _staging_parameters += obj_attr_list["aidrs"] + ' '
                         _staging_parameters += str(_staging) + ' ' 
                         _staging_parameters += obj_attr_list["temp_attr_list"] 
-                        _staging_parameters += " async"
+                        _staging_parameters += " nosync"
                                                       
                         _tmp_result = self.pause_app(obj_attr_list, \
                                                      _sub_channel, \
@@ -2435,7 +2435,7 @@ class ActiveObjectOperations(BaseObjectOperations) :
 
         try :
             
-            if "async" not in obj_attr_list or obj_attr_list["async"].lower() == "false" :
+            if "nosync" not in obj_attr_list or obj_attr_list["nosync"].lower() == "false" :
                 if threading.current_thread().abort :
                     _msg = "VM creation aborted during transfer file step..."
                     _status = 12345
@@ -5013,7 +5013,7 @@ class ActiveObjectOperations(BaseObjectOperations) :
                         _capture_vm_attr_list = {}
                         _msg = "About to call vmcapture method, from aicapture method"
                         cbdebug(_msg)
-                        if "async" in obj_attr_list and obj_attr_list["async"] == "true" :
+                        if "nosync" in obj_attr_list and obj_attr_list["nosync"] == "true" :
                             _status, _fmsg, _object = self.vmcapture(_capture_vm_attr_list, obj_attr_list["cloud_name"] + ' ' + _vm_name, "vm-capture")
                         elif not BaseObjectOperations.default_cloud :
                             _cloud_name = parameters.split()[0]

--- a/lib/operations/base_operations.py
+++ b/lib/operations/base_operations.py
@@ -180,7 +180,7 @@ class BaseObjectOperations :
             if not command.count("cloud-attach") and len(parameters.split()) > 0:
                 object_attribute_list["cloud_name"] = parameters.split()[0]
         else :
-            if not command.count("cloud-attach") and not parameters.count(" async"):
+            if not command.count("cloud-attach") and not parameters.count(" nosync"):
                 if len(parameters) > 0 :
                     _possible_cloud_name = parameters.split()[0]
                     if _possible_cloud_name == BaseObjectOperations.default_cloud :
@@ -4274,13 +4274,13 @@ class BaseObjectOperations :
             _obj_type = _obj_type.upper()
 
             # Some small pre-processing is in order. We just need to remove the
-            # word "async" from the parameter list
+            # word "nosync" from the parameter list
             _p_parameters = parameters.split()
             _parameters = ''
             _parallel_operations = 1
             _inter_spawn_time = False
             for _parameter in _p_parameters :
-                if not _parameter.count("async") :
+                if not _parameter.count("nosync") :
                     _parameters += _parameter + ' '
                 else :
                     if _parameter.count('=') :

--- a/regression/input_samples/test194.txt
+++ b/regression/input_samples/test194.txt
@@ -1,4 +1,4 @@
-vmcattach TESTCLOUD simzone_b async
+vmcattach TESTCLOUD simzone_b nosync
 waitfor TESTCLOUD 8s
 vmclist TESTCLOUD
 vmcshow TESTCLOUD simzone_b update_attempts,update_frequency

--- a/regression/input_samples/test196.txt
+++ b/regression/input_samples/test196.txt
@@ -1,4 +1,4 @@
-vmcattach TESTCLOUD simzone_d update_attempts=156,update_frequency=6 async
+vmcattach TESTCLOUD simzone_d update_attempts=156,update_frequency=6 nosync
 waitfor TESTCLOUD 8s
 vmclist TESTCLOUD
 vmcshow TESTCLOUD simzone_d update_attempts,update_frequency

--- a/regression/input_samples/test198.txt
+++ b/regression/input_samples/test198.txt
@@ -1,4 +1,4 @@
-vmcdetach TESTCLOUD simzone_a async
+vmcdetach TESTCLOUD simzone_a nosync
 waitfor TESTCLOUD 8s
 vmclist TESTCLOUD
 stats TESTCLOUD

--- a/regression/input_samples/test204.txt
+++ b/regression/input_samples/test204.txt
@@ -1,4 +1,4 @@
-vmcdetach TESTCLOUD all async
+vmcdetach TESTCLOUD all nosync
 waitfor TESTCLOUD 8s
 vmclist TESTCLOUD
 stats TESTCLOUD

--- a/regression/input_samples/test205.txt
+++ b/regression/input_samples/test205.txt
@@ -1,4 +1,4 @@
-vmcattach TESTCLOUD all async
+vmcattach TESTCLOUD all nosync
 waitfor TESTCLOUD 8s
 vmclist TESTCLOUD
 vmcshow TESTCLOUD simzone_c update_attempts,update_frequency

--- a/regression/input_samples/test221.txt
+++ b/regression/input_samples/test221.txt
@@ -1,4 +1,4 @@
-vmattach TESTCLOUD tinyvm async
+vmattach TESTCLOUD tinyvm nosync
 waitfor TESTCLOUD 1s
 vmlist TESTCLOUD pending
 waitfor TESTCLOUD 8s

--- a/regression/input_samples/test222.txt
+++ b/regression/input_samples/test222.txt
@@ -1,4 +1,4 @@
-vmattach TESTCLOUD tinyvm async=2
+vmattach TESTCLOUD tinyvm nosync=2
 waitfor TESTCLOUD 1s
 vmlist TESTCLOUD pending
 waituntil TESTCLOUD VM ARRIVED=8 increasing 1

--- a/regression/input_samples/test224.txt
+++ b/regression/input_samples/test224.txt
@@ -1,4 +1,4 @@
-vmattach TESTCLOUD db2 SUT A:B,X:Y,R:2 async
+vmattach TESTCLOUD db2 SUT A:B,X:Y,R:2 nosync
 waitfor TESTCLOUD 1s
 vmlist TESTCLOUD pending
 waitfor TESTCLOUD 8s

--- a/regression/input_samples/test225.txt
+++ b/regression/input_samples/test225.txt
@@ -1,4 +1,4 @@
-vmattach TESTCLOUD netclient simhosta2 A:B,X:Y,R:2 async
+vmattach TESTCLOUD netclient simhosta2 A:B,X:Y,R:2 nosync
 waitfor TESTCLOUD 1s
 vmlist TESTCLOUD pending
 waitfor TESTCLOUD 8s

--- a/regression/input_samples/test226.txt
+++ b/regression/input_samples/test226.txt
@@ -1,4 +1,4 @@
-vmattach TESTCLOUD fen_hpc auto empty size=platinum64,vmc_pool=LG async
+vmattach TESTCLOUD fen_hpc auto empty size=platinum64,vmc_pool=LG nosync
 waitfor TESTCLOUD 8s
 vmlist TESTCLOUD
 vmshow TESTCLOUD vm_11 vmc_name,vmc_pool,host_name,meta_tags,size

--- a/regression/input_samples/test227.txt
+++ b/regression/input_samples/test227.txt
@@ -1,4 +1,4 @@
-vmattach TESTCLOUD tinyvm auto empty iron32 pause_provision_complete async
+vmattach TESTCLOUD tinyvm auto empty iron32 pause_provision_complete nosync
 waitfor TESTCLOUD 8s
 msgpub TESTCLOUD VM staging vm_12;continue;something
 waituntil TESTCLOUD VM ARRIVING=0 decreasing 1

--- a/regression/input_samples/test228.txt
+++ b/regression/input_samples/test228.txt
@@ -1,6 +1,6 @@
 shell TESTCLOUD rm -rf /tmp/cb*_was_used_on_execution
 cldalter TESTCLOUD vm_defaults execute_script_name=/home/msilva/cloudbench/regression/..//regression/scripts/execute_on_staging.sh
-vmattach TESTCLOUD tinyvm auto empty iron32 execute_provision_complete async
+vmattach TESTCLOUD tinyvm auto empty iron32 execute_provision_complete nosync
 waituntil TESTCLOUD VM ARRIVING=0 decreasing 1
 shell TESTCLOUD ls /tmp/cb*_was_used_on_execution
 vmlist TESTCLOUD

--- a/regression/input_samples/test229.txt
+++ b/regression/input_samples/test229.txt
@@ -1,4 +1,4 @@
-vmattach TESTCLOUD predictablevm auto empty check_boot_started=subscribe_on_starting async
+vmattach TESTCLOUD predictablevm auto empty check_boot_started=subscribe_on_starting nosync
 waitfor TESTCLOUD 8s
 msgpub TESTCLOUD VM starting 11111111-1111-1111-1111-111111111111 has started
 waitfor TESTCLOUD 8s

--- a/regression/input_samples/test248.txt
+++ b/regression/input_samples/test248.txt
@@ -1,4 +1,4 @@
-vmdetach TESTCLOUD vm_5 async
+vmdetach TESTCLOUD vm_5 nosync
 waitfor TESTCLOUD 10s
 vmlist TESTCLOUD
 stats TESTCLOUD

--- a/regression/input_samples/test255.txt
+++ b/regression/input_samples/test255.txt
@@ -1,4 +1,4 @@
-vmattach TESTCLOUD willfail async
+vmattach TESTCLOUD willfail nosync
 waituntil TESTCLOUD VM ARRIVING=0 decreasing 1
 vmlist TESTCLOUD
 stats TESTCLOUD

--- a/regression/input_samples/test262.txt
+++ b/regression/input_samples/test262.txt
@@ -1,4 +1,4 @@
-aiattach TESTCLOUD hadoop async
+aiattach TESTCLOUD hadoop nosync
 waitfor TESTCLOUD 12s
 ailist TESTCLOUD
 vmlist TESTCLOUD

--- a/regression/input_samples/test270.txt
+++ b/regression/input_samples/test270.txt
@@ -1,4 +1,4 @@
-aiattach TESTCLOUD ibm_daytrader detach_parallelism=10,ssh_key_name=aaaabbbbccccddddeeee async 
+aiattach TESTCLOUD ibm_daytrader detach_parallelism=10,ssh_key_name=aaaabbbbccccddddeeee nosync 
 waitfor TESTCLOUD 18s
 ailist TESTCLOUD
 vmlist TESTCLOUD

--- a/regression/input_samples/test272.txt
+++ b/regression/input_samples/test272.txt
@@ -1,4 +1,4 @@
-aiattach TESTCLOUD hadoop hadoopslave_size=platinum64,sut=hadoopmaster->1_x_hadoopslave async
+aiattach TESTCLOUD hadoop hadoopslave_size=platinum64,sut=hadoopmaster->1_x_hadoopslave nosync
 waitfor TESTCLOUD 18s
 ailist TESTCLOUD
 vmlist TESTCLOUD

--- a/regression/input_samples/test278.txt
+++ b/regression/input_samples/test278.txt
@@ -1,4 +1,4 @@
-vmcapture TESTCLOUD vm_41 async
+vmcapture TESTCLOUD vm_41 nosync
 waitfor TESTCLOUD 25s
 ailist TESTCLOUD
 vmlist TESTCLOUD

--- a/regression/input_samples/test279.txt
+++ b/regression/input_samples/test279.txt
@@ -1,4 +1,4 @@
-vmcapture TESTCLOUD oldest async
+vmcapture TESTCLOUD oldest nosync
 waitfor TESTCLOUD 25s
 ailist TESTCLOUD
 vmlist TESTCLOUD

--- a/regression/input_samples/test288.txt
+++ b/regression/input_samples/test288.txt
@@ -1,1 +1,1 @@
-aiattach TESTCLOUD netperf async=4:2
+aiattach TESTCLOUD netperf nosync=4:2

--- a/regression/input_samples/test296.txt
+++ b/regression/input_samples/test296.txt
@@ -1,4 +1,4 @@
-aidetach TESTCLOUD ai_13 async
+aidetach TESTCLOUD ai_13 nosync
 waituntil TESTCLOUD AI RESERVATIONS=16 decreasing 5
 ailist TESTCLOUD
 vmlist TESTCLOUD

--- a/regression/input_samples/test302.txt
+++ b/regression/input_samples/test302.txt
@@ -1,4 +1,4 @@
-aicapture TESTCLOUD youngest async
+aicapture TESTCLOUD youngest nosync
 waituntil TESTCLOUD AI CAPTURING=0
 ailist TESTCLOUD
 vmlist TESTCLOUD

--- a/regression/input_samples/test304.txt
+++ b/regression/input_samples/test304.txt
@@ -1,4 +1,4 @@
-aiattach TESTCLOUD ibm_daytrader default default none none pause_all_vms_booted async
+aiattach TESTCLOUD ibm_daytrader default default none none pause_all_vms_booted nosync
 waitfor TESTCLOUD 15s
 msgpub TESTCLOUD VM staging ai_26;continue;something
 waituntil TESTCLOUD AI ARRIVING=0 decreasing 1

--- a/regression/input_samples/test328.txt
+++ b/regression/input_samples/test328.txt
@@ -1,4 +1,4 @@
-vmmigrate TESTCLOUD youngest source async
+vmmigrate TESTCLOUD youngest source nosync
 waitfor TESTCLOUD 10s
 stats TESTCLOUD
 vmlist TESTCLOUD

--- a/regression/input_samples/test330.txt
+++ b/regression/input_samples/test330.txt
@@ -1,4 +1,4 @@
-vmprotect TESTCLOUD youngest source async
+vmprotect TESTCLOUD youngest source nosync
 waitfor TESTCLOUD 10s
 stats TESTCLOUD
 vmlist TESTCLOUD

--- a/regression/input_samples/test461.txt
+++ b/regression/input_samples/test461.txt
@@ -1,4 +1,4 @@
-vmcattach simzone_b async
+vmcattach simzone_b nosync
 waitfor 8s
 vmclist
 vmcshow simzone_b update_attempts,update_frequency

--- a/regression/input_samples/test463.txt
+++ b/regression/input_samples/test463.txt
@@ -1,4 +1,4 @@
-vmcattach simzone_d update_attempts=156,update_frequency=6 async
+vmcattach simzone_d update_attempts=156,update_frequency=6 nosync
 waitfor 8s
 vmclist
 vmcshow simzone_d update_attempts,update_frequency

--- a/regression/input_samples/test465.txt
+++ b/regression/input_samples/test465.txt
@@ -1,4 +1,4 @@
-vmcdetach simzone_a async
+vmcdetach simzone_a nosync
 waitfor 8s
 vmclist
 stats

--- a/regression/input_samples/test471.txt
+++ b/regression/input_samples/test471.txt
@@ -1,4 +1,4 @@
-vmcdetach all async
+vmcdetach all nosync
 waitfor 8s
 vmclist
 stats

--- a/regression/input_samples/test472.txt
+++ b/regression/input_samples/test472.txt
@@ -1,4 +1,4 @@
-vmcattach all async
+vmcattach all nosync
 waitfor 8s
 vmclist
 vmcshow simzone_c update_attempts,update_frequency

--- a/regression/input_samples/test488.txt
+++ b/regression/input_samples/test488.txt
@@ -1,4 +1,4 @@
-vmattach tinyvm async
+vmattach tinyvm nosync
 waitfor 1s
 vmlist pending
 waitfor 8s

--- a/regression/input_samples/test489.txt
+++ b/regression/input_samples/test489.txt
@@ -1,4 +1,4 @@
-vmattach tinyvm async=2
+vmattach tinyvm nosync=2
 waitfor 1s
 vmlist pending
 waituntil VM ARRIVED=8 increasing 1

--- a/regression/input_samples/test491.txt
+++ b/regression/input_samples/test491.txt
@@ -1,4 +1,4 @@
-vmattach db2 SUT A:B,X:Y,R:2 async
+vmattach db2 SUT A:B,X:Y,R:2 nosync
 waitfor 1s
 vmlist pending
 waitfor 8s

--- a/regression/input_samples/test492.txt
+++ b/regression/input_samples/test492.txt
@@ -1,4 +1,4 @@
-vmattach netclient simhosta2 A:B,X:Y,R:2 async
+vmattach netclient simhosta2 A:B,X:Y,R:2 nosync
 waitfor 1s
 vmlist pending
 waitfor 8s

--- a/regression/input_samples/test493.txt
+++ b/regression/input_samples/test493.txt
@@ -1,4 +1,4 @@
-vmattach fen_hpc auto empty size=platinum64,vmc_pool=LG async
+vmattach fen_hpc auto empty size=platinum64,vmc_pool=LG nosync
 waitfor 8s
 vmlist
 vmshow vm_11 vmc_name,vmc_pool,host_name,meta_tags,size

--- a/regression/input_samples/test494.txt
+++ b/regression/input_samples/test494.txt
@@ -1,4 +1,4 @@
-vmattach tinyvm auto empty iron32 pause_provision_complete async
+vmattach tinyvm auto empty iron32 pause_provision_complete nosync
 waitfor 8s
 msgpub VM staging vm_12;continue;something
 waituntil VM ARRIVING=0 decreasing 1

--- a/regression/input_samples/test495.txt
+++ b/regression/input_samples/test495.txt
@@ -1,6 +1,6 @@
 shell rm -rf /tmp/cb*_was_used_on_execution
 cldalter vm_defaults execute_script_name=/home/msilva/cloudbench/regression/..//regression/scripts/execute_on_staging.sh
-vmattach tinyvm auto empty iron32 execute_provision_complete async
+vmattach tinyvm auto empty iron32 execute_provision_complete nosync
 waituntil VM ARRIVING=0 decreasing 1
 shell ls /tmp/cb*_was_used_on_execution
 vmlist

--- a/regression/input_samples/test496.txt
+++ b/regression/input_samples/test496.txt
@@ -1,4 +1,4 @@
-vmattach predictablevm auto empty check_boot_started=subscribe_on_starting async
+vmattach predictablevm auto empty check_boot_started=subscribe_on_starting nosync
 waitfor 8s
 msgpub VM starting 11111111-1111-1111-1111-111111111111 has started
 waitfor 8s

--- a/regression/input_samples/test515.txt
+++ b/regression/input_samples/test515.txt
@@ -1,4 +1,4 @@
-vmdetach vm_5 async
+vmdetach vm_5 nosync
 waitfor 10s
 vmlist
 stats

--- a/regression/input_samples/test522.txt
+++ b/regression/input_samples/test522.txt
@@ -1,4 +1,4 @@
-vmattach willfail async
+vmattach willfail nosync
 waituntil VM ARRIVING=0 decreasing 1
 vmlist
 stats

--- a/regression/input_samples/test529.txt
+++ b/regression/input_samples/test529.txt
@@ -1,4 +1,4 @@
-aiattach hadoop async
+aiattach hadoop nosync
 waitfor 12s
 ailist
 vmlist

--- a/regression/input_samples/test537.txt
+++ b/regression/input_samples/test537.txt
@@ -1,4 +1,4 @@
-aiattach ibm_daytrader detach_parallelism=10,ssh_key_name=aaaabbbbccccddddeeee async 
+aiattach ibm_daytrader detach_parallelism=10,ssh_key_name=aaaabbbbccccddddeeee nosync 
 waitfor 18s
 ailist
 vmlist

--- a/regression/input_samples/test539.txt
+++ b/regression/input_samples/test539.txt
@@ -1,4 +1,4 @@
-aiattach hadoop hadoopslave_size=platinum64,sut=hadoopmaster->1_x_hadoopslave async
+aiattach hadoop hadoopslave_size=platinum64,sut=hadoopmaster->1_x_hadoopslave nosync
 waitfor 18s
 ailist
 vmlist

--- a/regression/input_samples/test545.txt
+++ b/regression/input_samples/test545.txt
@@ -1,4 +1,4 @@
-vmcapture vm_41 async
+vmcapture vm_41 nosync
 waitfor 25s
 ailist
 vmlist

--- a/regression/input_samples/test546.txt
+++ b/regression/input_samples/test546.txt
@@ -1,4 +1,4 @@
-vmcapture oldest async
+vmcapture oldest nosync
 waitfor 25s
 ailist
 vmlist

--- a/regression/input_samples/test555.txt
+++ b/regression/input_samples/test555.txt
@@ -1,1 +1,1 @@
-aiattach netperf async=4:2
+aiattach netperf nosync=4:2

--- a/regression/input_samples/test563.txt
+++ b/regression/input_samples/test563.txt
@@ -1,4 +1,4 @@
-aidetach ai_13 async
+aidetach ai_13 nosync
 waituntil AI RESERVATIONS=16 decreasing 5
 ailist
 vmlist

--- a/regression/input_samples/test569.txt
+++ b/regression/input_samples/test569.txt
@@ -1,4 +1,4 @@
-aicapture youngest async
+aicapture youngest nosync
 waituntil AI CAPTURING=0
 ailist
 vmlist

--- a/regression/input_samples/test571.txt
+++ b/regression/input_samples/test571.txt
@@ -1,4 +1,4 @@
-aiattach ibm_daytrader default default none none pause_all_vms_booted async
+aiattach ibm_daytrader default default none none pause_all_vms_booted nosync
 waitfor 15s
 msgpub VM staging ai_26;continue;something
 waituntil AI ARRIVING=0 decreasing 1

--- a/regression/input_samples/test595.txt
+++ b/regression/input_samples/test595.txt
@@ -1,4 +1,4 @@
-vmmigrate youngest source async
+vmmigrate youngest source nosync
 waitfor 10s
 stats
 vmlist

--- a/regression/input_samples/test597.txt
+++ b/regression/input_samples/test597.txt
@@ -1,4 +1,4 @@
-vmprotect youngest source async
+vmprotect youngest source nosync
 waitfor 10s
 stats
 vmlist

--- a/regression/regression_test_experiment_plan.txt
+++ b/regression/regression_test_experiment_plan.txt
@@ -787,13 +787,13 @@ echo ######################################################### [TEST] 196: START
 vmccleanup MYSIM simzone_a
 echo ########################################################## [TEST] 196: END vmccleanup MYSIM simzone_a ##########################################################
 echo 
-echo ###################################################### [TEST] 197: START vmcattach MYSIM simzone_b async #######################################################
-vmcattach MYSIM simzone_b async
+echo ###################################################### [TEST] 197: START vmcattach MYSIM simzone_b nosync #######################################################
+vmcattach MYSIM simzone_b nosync
 waitfor MYSIM 16s
 vmclist MYSIM
 vmcshow MYSIM simzone_b update_attempts,update_frequency
 stats MYSIM
-echo ####################################################### [TEST] 197: END vmcattach MYSIM simzone_b async ########################################################
+echo ####################################################### [TEST] 197: END vmcattach MYSIM simzone_b nosync ########################################################
 echo 
 echo ###################################### [TEST] 198: START vmcattach MYSIM simzone_c update_attempts=78,update_frequency=3 #######################################
 vmcattach MYSIM simzone_c update_attempts=78,update_frequency=3
@@ -802,13 +802,13 @@ vmcshow MYSIM simzone_c update_attempts,update_frequency
 stats MYSIM
 echo ####################################### [TEST] 198: END vmcattach MYSIM simzone_c update_attempts=78,update_frequency=3 ########################################
 echo 
-echo ################################### [TEST] 199: START vmcattach MYSIM simzone_d update_attempts=156,update_frequency=6 async ###################################
-vmcattach MYSIM simzone_d update_attempts=156,update_frequency=6 async
+echo ################################### [TEST] 199: START vmcattach MYSIM simzone_d update_attempts=156,update_frequency=6 nosync ###################################
+vmcattach MYSIM simzone_d update_attempts=156,update_frequency=6 nosync
 waitfor MYSIM 16s
 vmclist MYSIM
 vmcshow MYSIM simzone_d update_attempts,update_frequency
 stats MYSIM
-echo #################################### [TEST] 199: END vmcattach MYSIM simzone_d update_attempts=156,update_frequency=6 async ####################################
+echo #################################### [TEST] 199: END vmcattach MYSIM simzone_d update_attempts=156,update_frequency=6 nosync ####################################
 echo 
 echo ######################################################### [TEST] 200: START vmcdetach MYSIM simzone_d ##########################################################
 vmcdetach MYSIM simzone_d
@@ -818,12 +818,12 @@ vmclist MYSIM
 stats MYSIM
 echo ########################################################## [TEST] 200: END vmcdetach MYSIM simzone_d ###########################################################
 echo 
-echo ###################################################### [TEST] 201: START vmcdetach MYSIM simzone_a async #######################################################
-vmcdetach MYSIM simzone_a async
+echo ###################################################### [TEST] 201: START vmcdetach MYSIM simzone_a nosync #######################################################
+vmcdetach MYSIM simzone_a nosync
 waitfor MYSIM 16s
 vmclist MYSIM
 stats MYSIM
-echo ####################################################### [TEST] 201: END vmcdetach MYSIM simzone_a async ########################################################
+echo ####################################################### [TEST] 201: END vmcdetach MYSIM simzone_a nosync ########################################################
 echo 
 echo ############################################################ [TEST] 202: START vmcattach MYSIM all #############################################################
 vmcattach MYSIM all
@@ -856,20 +856,20 @@ vmcshow MYSIM simzone_c update_attempts,update_frequency
 stats MYSIM
 echo ######################################### [TEST] 206: END vmcattach MYSIM update_attempts=312,update_frequency=12 all ##########################################
 echo 
-echo ######################################################### [TEST] 207: START vmcdetach MYSIM all async ##########################################################
-vmcdetach MYSIM all async
+echo ######################################################### [TEST] 207: START vmcdetach MYSIM all nosync ##########################################################
+vmcdetach MYSIM all nosync
 waitfor MYSIM 20s
 vmclist MYSIM
 stats MYSIM
-echo ########################################################## [TEST] 207: END vmcdetach MYSIM all async ###########################################################
+echo ########################################################## [TEST] 207: END vmcdetach MYSIM all nosync ###########################################################
 echo 
-echo ######################################################### [TEST] 208: START vmcattach MYSIM all async ##########################################################
-vmcattach MYSIM all async
+echo ######################################################### [TEST] 208: START vmcattach MYSIM all nosync ##########################################################
+vmcattach MYSIM all nosync
 waitfor MYSIM 30s
 vmclist MYSIM
 vmcshow MYSIM simzone_c update_attempts,update_frequency
 stats MYSIM
-echo ########################################################## [TEST] 208: END vmcattach MYSIM all async ###########################################################
+echo ########################################################## [TEST] 208: END vmcattach MYSIM all nosync ###########################################################
 echo 
 echo ############################################## [TEST] 209: START vmcalter MYSIM simzone_a replication_vmcs=TESTE ###############################################
 vmcalter MYSIM simzone_a replication_vmcs=TESTE
@@ -949,83 +949,83 @@ vmlist MYSIM
 stats MYSIM
 echo ############################################################# [TEST] 223: END vmcapture MYSIM vm_2 #############################################################
 echo 
-echo ######################################################## [TEST] 224: START vmattach MYSIM tinyvm async #########################################################
-vmattach MYSIM tinyvm async
+echo ######################################################## [TEST] 224: START vmattach MYSIM tinyvm nosync #########################################################
+vmattach MYSIM tinyvm nosync
 waitfor MYSIM 1s
 vmlist MYSIM pending
 waitfor MYSIM 16s
 vmlist MYSIM
 stats MYSIM
-echo ######################################################### [TEST] 224: END vmattach MYSIM tinyvm async ##########################################################
+echo ######################################################### [TEST] 224: END vmattach MYSIM tinyvm nosync ##########################################################
 echo 
-echo ####################################################### [TEST] 225: START vmattach MYSIM tinyvm async=2 ########################################################
-vmattach MYSIM tinyvm async=2
+echo ####################################################### [TEST] 225: START vmattach MYSIM tinyvm nosync=2 ########################################################
+vmattach MYSIM tinyvm nosync=2
 waitfor MYSIM 1s
 vmlist MYSIM pending
 waituntil MYSIM VM ARRIVED=8 increasing 1
 vmlist MYSIM
 stats MYSIM
-echo ######################################################## [TEST] 225: END vmattach MYSIM tinyvm async=2 #########################################################
+echo ######################################################## [TEST] 225: END vmattach MYSIM tinyvm nosync=2 #########################################################
 echo 
 echo #################################################### [TEST] 226: START rolealter MYSIM db2 size=platinum64 #####################################################
 rolealter MYSIM db2 size=platinum64
 echo ##################################################### [TEST] 226: END rolealter MYSIM db2 size=platinum64 ######################################################
 echo 
-echo ################################################## [TEST] 227: START vmattach MYSIM db2 SUT A:B,X:Y,R:2 async ##################################################
-vmattach MYSIM db2 SUT A:B,X:Y,R:2 async
+echo ################################################## [TEST] 227: START vmattach MYSIM db2 SUT A:B,X:Y,R:2 nosync ##################################################
+vmattach MYSIM db2 SUT A:B,X:Y,R:2 nosync
 waitfor MYSIM 1s
 vmlist MYSIM pending
 waitfor MYSIM 16s
 vmlist MYSIM
 vmshow MYSIM vm_9 role,vmc_name,vmc_pool,host_name,meta_tags,size
 stats MYSIM
-echo ################################################### [TEST] 227: END vmattach MYSIM db2 SUT A:B,X:Y,R:2 async ###################################################
+echo ################################################### [TEST] 227: END vmattach MYSIM db2 SUT A:B,X:Y,R:2 nosync ###################################################
 echo 
-echo ############################################ [TEST] 228: START vmattach MYSIM netclient simhosta2 A:B,X:Y,R:2 async ############################################
-vmattach MYSIM netclient simhosta2 A:B,X:Y,R:2 async
+echo ############################################ [TEST] 228: START vmattach MYSIM netclient simhosta2 A:B,X:Y,R:2 nosync ############################################
+vmattach MYSIM netclient simhosta2 A:B,X:Y,R:2 nosync
 waitfor MYSIM 1s
 vmlist MYSIM pending
 waitfor MYSIM 16s
 vmlist MYSIM
 vmshow MYSIM vm_10 role,vmc_name,vmc_pool,host_name,meta_tags,size
 stats MYSIM
-echo ############################################# [TEST] 228: END vmattach MYSIM netclient simhosta2 A:B,X:Y,R:2 async #############################################
+echo ############################################# [TEST] 228: END vmattach MYSIM netclient simhosta2 A:B,X:Y,R:2 nosync #############################################
 echo 
-echo #################################### [TEST] 229: START vmattach MYSIM fen_hpc auto empty size=platinum64,vmc_pool=LG async #####################################
-vmattach MYSIM fen_hpc auto empty size=platinum64,vmc_pool=LG async
+echo #################################### [TEST] 229: START vmattach MYSIM fen_hpc auto empty size=platinum64,vmc_pool=LG nosync #####################################
+vmattach MYSIM fen_hpc auto empty size=platinum64,vmc_pool=LG nosync
 waitfor MYSIM 16s
 vmlist MYSIM
 vmshow MYSIM vm_11 vmc_name,vmc_pool,host_name,meta_tags,size
 stats MYSIM
-echo ##################################### [TEST] 229: END vmattach MYSIM fen_hpc auto empty size=platinum64,vmc_pool=LG async ######################################
+echo ##################################### [TEST] 229: END vmattach MYSIM fen_hpc auto empty size=platinum64,vmc_pool=LG nosync ######################################
 echo 
-echo ################################### [TEST] 230: START vmattach MYSIM tinyvm auto empty iron32 pause_provision_complete async ###################################
-vmattach MYSIM tinyvm auto empty iron32 pause_provision_complete async
+echo ################################### [TEST] 230: START vmattach MYSIM tinyvm auto empty iron32 pause_provision_complete nosync ###################################
+vmattach MYSIM tinyvm auto empty iron32 pause_provision_complete nosync
 waitfor MYSIM 16s
 msgpub MYSIM VM staging vm_12;continue;something
 waituntil MYSIM VM ARRIVING=0 decreasing 1
 vmlist MYSIM
 stats MYSIM
-echo #################################### [TEST] 230: END vmattach MYSIM tinyvm auto empty iron32 pause_provision_complete async ####################################
+echo #################################### [TEST] 230: END vmattach MYSIM tinyvm auto empty iron32 pause_provision_complete nosync ####################################
 echo 
 echo ############################################# [TEST] 231: START shell MYSIM rm -rf /tmp/cb*_was_used_on_execution ##############################################
 shell MYSIM rm -rf /tmp/cb*_was_used_on_execution
 cldalter MYSIM vm_defaults execute_script_name=~/repos/cloudbench/regression/..//regression/scripts/execute_on_staging.sh
-vmattach MYSIM tinyvm auto empty iron32 execute_provision_complete async
+vmattach MYSIM tinyvm auto empty iron32 execute_provision_complete nosync
 waituntil MYSIM VM ARRIVING=0 decreasing 1
 shell MYSIM ls /tmp/cb*_was_used_on_execution
 vmlist MYSIM
 stats MYSIM
 echo ############################################## [TEST] 231: END shell MYSIM rm -rf /tmp/cb*_was_used_on_execution ###############################################
 echo 
-echo ########################### [TEST] 232: START vmattach MYSIM predictablevm auto empty check_boot_started=subscribe_on_starting async ###########################
-vmattach MYSIM predictablevm auto empty check_boot_started=subscribe_on_starting async
+echo ########################### [TEST] 232: START vmattach MYSIM predictablevm auto empty check_boot_started=subscribe_on_starting nosync ###########################
+vmattach MYSIM predictablevm auto empty check_boot_started=subscribe_on_starting nosync
 waitfor MYSIM 16s
 msgpub MYSIM VM starting 11111111-1111-1111-1111-111111111111 has started
 waitfor MYSIM 16s
 vmlist MYSIM
 stats MYSIM
-echo ############################ [TEST] 232: END vmattach MYSIM predictablevm auto empty check_boot_started=subscribe_on_starting async ############################
+echo ############################ [TEST] 232: END vmattach MYSIM predictablevm auto empty check_boot_started=subscribe_on_starting nosync ############################
 echo 
 echo ########################################################### [TEST] 233: START vmattach MYSIM tinyvm ############################################################
 vmattach MYSIM tinyvm
@@ -1129,12 +1129,12 @@ vmlist MYSIM
 stats MYSIM
 echo ############################################################# [TEST] 250: END vmdetach MYSIM vm_4 ##############################################################
 echo 
-echo ######################################################### [TEST] 251: START vmdetach MYSIM vm_5 async ##########################################################
-vmdetach MYSIM vm_5 async
+echo ######################################################### [TEST] 251: START vmdetach MYSIM vm_5 nosync ##########################################################
+vmdetach MYSIM vm_5 nosync
 waitfor MYSIM 10s
 vmlist MYSIM
 stats MYSIM
-echo ########################################################## [TEST] 251: END vmdetach MYSIM vm_5 async ###########################################################
+echo ########################################################## [TEST] 251: END vmdetach MYSIM vm_5 nosync ###########################################################
 echo 
 echo ########################################################### [TEST] 252: START vmdetach MYSIM oldest ############################################################
 vmdetach MYSIM oldest
@@ -1172,12 +1172,12 @@ vmlist MYSIM
 stats MYSIM
 echo ########################################################### [TEST] 257: END vmattach MYSIM willfail ############################################################
 echo 
-echo ####################################################### [TEST] 258: START vmattach MYSIM willfail async ########################################################
-vmattach MYSIM willfail async
+echo ####################################################### [TEST] 258: START vmattach MYSIM willfail nosync ########################################################
+vmattach MYSIM willfail nosync
 waituntil MYSIM VM ARRIVING=0 decreasing 1
 vmlist MYSIM
 stats MYSIM
-echo ######################################################## [TEST] 258: END vmattach MYSIM willfail async #########################################################
+echo ######################################################## [TEST] 258: END vmattach MYSIM willfail nosync #########################################################
 echo 
 echo ########################################################### [TEST] 259: START vmlist MYSIM finished ############################################################
 vmlist MYSIM finished
@@ -1208,14 +1208,14 @@ aialter MYSIM ai_1 mode=scalable
 aishow MYSIM ai_1 mode
 echo ####################################################### [TEST] 264: END aialter MYSIM ai_1 mode=scalable #######################################################
 echo 
-echo ######################################################## [TEST] 265: START aiattach MYSIM hadoop async #########################################################
-aiattach MYSIM hadoop async
+echo ######################################################## [TEST] 265: START aiattach MYSIM hadoop nosync #########################################################
+aiattach MYSIM hadoop nosync
 waitfor MYSIM 30s
 ailist MYSIM
 vmlist MYSIM
 aishow MYSIM ai_2 detach_parallelism,ssh_key_name,sut
 stats MYSIM
-echo ######################################################### [TEST] 265: END aiattach MYSIM hadoop async ##########################################################
+echo ######################################################### [TEST] 265: END aiattach MYSIM hadoop nosync ##########################################################
 echo 
 echo ############################ [TEST] 266: START aiattach MYSIM ibm_daytrader detach_parallelism=9,ssh_key_name=AAAABBBBCCCCDDDDEEEE #############################
 aiattach MYSIM ibm_daytrader detach_parallelism=9,ssh_key_name=AAAABBBBCCCCDDDDEEEE
@@ -1261,14 +1261,14 @@ stateshow MYSIM
 stats MYSIM
 echo ############################################################# [TEST] 272: END airestore MYSIM ai_3 #############################################################
 echo 
-echo ######################## [TEST] 273: START aiattach MYSIM ibm_daytrader detach_parallelism=10,ssh_key_name=aaaabbbbccccddddeeee async  #########################
-aiattach MYSIM ibm_daytrader detach_parallelism=10,ssh_key_name=aaaabbbbccccddddeeee async 
+echo ######################## [TEST] 273: START aiattach MYSIM ibm_daytrader detach_parallelism=10,ssh_key_name=aaaabbbbccccddddeeee nosync  #########################
+aiattach MYSIM ibm_daytrader detach_parallelism=10,ssh_key_name=aaaabbbbccccddddeeee nosync 
 waitfor MYSIM 18s
 ailist MYSIM
 vmlist MYSIM
 aishow MYSIM ai_4 detach_parallelism,ssh_key_name,sut
 stats MYSIM
-echo ######################### [TEST] 273: END aiattach MYSIM ibm_daytrader detach_parallelism=10,ssh_key_name=aaaabbbbccccddddeeee async  ##########################
+echo ######################### [TEST] 273: END aiattach MYSIM ibm_daytrader detach_parallelism=10,ssh_key_name=aaaabbbbccccddddeeee nosync  ##########################
 echo 
 echo ################################## [TEST] 274: START aiattach MYSIM netperf netclient_pref_pool=SUT,netclient_size=platinum64 ##################################
 aiattach MYSIM netperf netclient_pref_pool=SUT,netclient_size=platinum64
@@ -1278,14 +1278,14 @@ aishow MYSIM ai_5 detach_parallelism,ssh_key_name,sut
 stats MYSIM
 echo ################################### [TEST] 274: END aiattach MYSIM netperf netclient_pref_pool=SUT,netclient_size=platinum64 ###################################
 echo 
-echo ######################### [TEST] 275: START aiattach MYSIM hadoop hadoopslave_size=platinum64,sut=hadoopmaster->1_x_hadoopslave async ##########################
-aiattach MYSIM hadoop hadoopslave_size=platinum64,sut=hadoopmaster->1_x_hadoopslave async
+echo ######################### [TEST] 275: START aiattach MYSIM hadoop hadoopslave_size=platinum64,sut=hadoopmaster->1_x_hadoopslave nosync ##########################
+aiattach MYSIM hadoop hadoopslave_size=platinum64,sut=hadoopmaster->1_x_hadoopslave nosync
 waitfor MYSIM 18s
 ailist MYSIM
 vmlist MYSIM
 aishow MYSIM ai_6 detach_parallelism,ssh_key_name,sut
 stats MYSIM
-echo ########################## [TEST] 275: END aiattach MYSIM hadoop hadoopslave_size=platinum64,sut=hadoopmaster->1_x_hadoopslave async ###########################
+echo ########################## [TEST] 275: END aiattach MYSIM hadoop hadoopslave_size=platinum64,sut=hadoopmaster->1_x_hadoopslave nosync ###########################
 echo 
 echo ######################################################### [TEST] 276: START airesize MYSIM ai_1 was +1 #########################################################
 airesize MYSIM ai_1 was +1
@@ -1326,21 +1326,21 @@ vmlist MYSIM
 stats MYSIM
 echo ########################################################### [TEST] 280: END vmcapture MYSIM youngest ###########################################################
 echo 
-echo ######################################################## [TEST] 281: START vmcapture MYSIM vm_41 async #########################################################
-vmcapture MYSIM vm_41 async
+echo ######################################################## [TEST] 281: START vmcapture MYSIM vm_41 nosync #########################################################
+vmcapture MYSIM vm_41 nosync
 waitfor MYSIM 25s
 ailist MYSIM
 vmlist MYSIM
 stats MYSIM
-echo ######################################################### [TEST] 281: END vmcapture MYSIM vm_41 async ##########################################################
+echo ######################################################### [TEST] 281: END vmcapture MYSIM vm_41 nosync ##########################################################
 echo 
-echo ######################################################## [TEST] 282: START vmcapture MYSIM oldest async ########################################################
-vmcapture MYSIM oldest async
+echo ######################################################## [TEST] 282: START vmcapture MYSIM oldest nosync ########################################################
+vmcapture MYSIM oldest nosync
 waitfor MYSIM 25s
 ailist MYSIM
 vmlist MYSIM
 stats MYSIM
-echo ######################################################### [TEST] 282: END vmcapture MYSIM oldest async #########################################################
+echo ######################################################### [TEST] 282: END vmcapture MYSIM oldest nosync #########################################################
 echo 
 echo ############################################## [TEST] 283: START aiattach MYSIM ibm_daytrader load_balancer=true ###############################################
 aiattach MYSIM ibm_daytrader load_balancer=true
@@ -1399,9 +1399,9 @@ aishow MYSIM ai_13 load_balancer,sut
 stats MYSIM
 echo ######################################################### [TEST] 290: END aiattach MYSIM ibm_daytrader #########################################################
 echo 
-echo ###################################################### [TEST] 291: START aiattach MYSIM netperf async=4:2 ######################################################
-aiattach MYSIM netperf async=4:2
-echo ####################################################### [TEST] 291: END aiattach MYSIM netperf async=4:2 #######################################################
+echo ###################################################### [TEST] 291: START aiattach MYSIM netperf nosync=4:2 ######################################################
+aiattach MYSIM netperf nosync=4:2
+echo ####################################################### [TEST] 291: END aiattach MYSIM netperf nosync=4:2 #######################################################
 echo 
 echo ################################################# [TEST] 292: START waituntil MYSIM AI ARRIVED=17 increasing 2 #################################################
 waituntil MYSIM AI ARRIVED=17 increasing 2
@@ -1452,13 +1452,13 @@ vmlist MYSIM
 stats MYSIM
 echo ############################################################# [TEST] 298: END aidetach MYSIM ai_12 #############################################################
 echo 
-echo ######################################################### [TEST] 299: START aidetach MYSIM ai_13 async #########################################################
-aidetach MYSIM ai_13 async
+echo ######################################################### [TEST] 299: START aidetach MYSIM ai_13 nosync #########################################################
+aidetach MYSIM ai_13 nosync
 waituntil MYSIM AI RESERVATIONS=16 decreasing 5
 ailist MYSIM
 vmlist MYSIM
 stats MYSIM
-echo ########################################################## [TEST] 299: END aidetach MYSIM ai_13 async ##########################################################
+echo ########################################################## [TEST] 299: END aidetach MYSIM ai_13 nosync ##########################################################
 echo 
 echo ########################################################### [TEST] 300: START aidetach MYSIM oldest ############################################################
 aidetach MYSIM oldest
@@ -1497,13 +1497,13 @@ vmlist MYSIM
 stats MYSIM
 echo ############################################################ [TEST] 304: END aicapture MYSIM oldest ############################################################
 echo 
-echo ####################################################### [TEST] 305: START aicapture MYSIM youngest async #######################################################
-aicapture MYSIM youngest async
+echo ####################################################### [TEST] 305: START aicapture MYSIM youngest nosync #######################################################
+aicapture MYSIM youngest nosync
 waituntil MYSIM AI CAPTURING=0
 ailist MYSIM
 vmlist MYSIM
 stats MYSIM
-echo ######################################################## [TEST] 305: END aicapture MYSIM youngest async ########################################################
+echo ######################################################## [TEST] 305: END aicapture MYSIM youngest nosync ########################################################
 echo 
 echo ########################################################### [TEST] 306: START aidetach MYSIM random ############################################################
 aidetach MYSIM random
@@ -1512,15 +1512,15 @@ vmlist MYSIM
 stats MYSIM
 echo ############################################################ [TEST] 306: END aidetach MYSIM random #############################################################
 echo 
-echo ############################# [TEST] 307: START aiattach MYSIM ibm_daytrader default default none none pause_all_vms_booted async ##############################
-aiattach MYSIM ibm_daytrader default default none none pause_all_vms_booted async
+echo ############################# [TEST] 307: START aiattach MYSIM ibm_daytrader default default none none pause_all_vms_booted nosync ##############################
+aiattach MYSIM ibm_daytrader default default none none pause_all_vms_booted nosync
 waitfor MYSIM 40s
 msgpub MYSIM VM staging ai_26;continue;something
 waituntil MYSIM AI ARRIVING=0 decreasing 1
 ailist MYSIM
 vmlist MYSIM
 stats MYSIM
-echo ############################## [TEST] 307: END aiattach MYSIM ibm_daytrader default default none none pause_all_vms_booted async ###############################
+echo ############################## [TEST] 307: END aiattach MYSIM ibm_daytrader default default none none pause_all_vms_booted nosync ###############################
 echo 
 echo ############################################# [TEST] 308: START shell MYSIM rm -rf /tmp/cb*_was_used_on_execution ##############################################
 shell MYSIM rm -rf /tmp/cb*_was_used_on_execution
@@ -1678,12 +1678,12 @@ stats MYSIM
 vmlist MYSIM
 echo ######################################################## [TEST] 330: END vmmigrate MYSIM youngest dest #########################################################
 echo 
-echo ################################################### [TEST] 331: START vmmigrate MYSIM youngest source async ####################################################
-vmmigrate MYSIM youngest source async
+echo ################################################### [TEST] 331: START vmmigrate MYSIM youngest source nosync ####################################################
+vmmigrate MYSIM youngest source nosync
 waitfor MYSIM 10s
 stats MYSIM
 vmlist MYSIM
-echo #################################################### [TEST] 331: END vmmigrate MYSIM youngest source async #####################################################
+echo #################################################### [TEST] 331: END vmmigrate MYSIM youngest source nosync #####################################################
 echo 
 echo ####################################################### [TEST] 332: START vmprotect MYSIM youngest dest ########################################################
 vmprotect MYSIM youngest dest
@@ -1691,12 +1691,12 @@ stats MYSIM
 vmlist MYSIM
 echo ######################################################## [TEST] 332: END vmprotect MYSIM youngest dest #########################################################
 echo 
-echo ################################################### [TEST] 333: START vmprotect MYSIM youngest source async ####################################################
-vmprotect MYSIM youngest source async
+echo ################################################### [TEST] 333: START vmprotect MYSIM youngest source nosync ####################################################
+vmprotect MYSIM youngest source nosync
 waitfor MYSIM 10s
 stats MYSIM
 vmlist MYSIM
-echo #################################################### [TEST] 333: END vmprotect MYSIM youngest source async #####################################################
+echo #################################################### [TEST] 333: END vmprotect MYSIM youngest source nosync #####################################################
 echo 
 echo ############################################################# [TEST] 334: START reserved for vmcrs #############################################################
 reserved for vmcrs
@@ -2271,13 +2271,13 @@ echo ############################################################ [TEST] 473: ST
 vmccleanup simzone_a
 echo ############################################################# [TEST] 473: END vmccleanup simzone_a #############################################################
 echo 
-echo ######################################################### [TEST] 474: START vmcattach simzone_b async ##########################################################
-vmcattach simzone_b async
+echo ######################################################### [TEST] 474: START vmcattach simzone_b nosync ##########################################################
+vmcattach simzone_b nosync
 waitfor 16s
 vmclist
 vmcshow simzone_b update_attempts,update_frequency
 stats
-echo ########################################################## [TEST] 474: END vmcattach simzone_b async ###########################################################
+echo ########################################################## [TEST] 474: END vmcattach simzone_b nosync ###########################################################
 echo 
 echo ######################################### [TEST] 475: START vmcattach simzone_c update_attempts=78,update_frequency=3 ##########################################
 vmcattach simzone_c update_attempts=78,update_frequency=3
@@ -2286,13 +2286,13 @@ vmcshow simzone_c update_attempts,update_frequency
 stats
 echo ########################################## [TEST] 475: END vmcattach simzone_c update_attempts=78,update_frequency=3 ###########################################
 echo 
-echo ###################################### [TEST] 476: START vmcattach simzone_d update_attempts=156,update_frequency=6 async ######################################
-vmcattach simzone_d update_attempts=156,update_frequency=6 async
+echo ###################################### [TEST] 476: START vmcattach simzone_d update_attempts=156,update_frequency=6 nosync ######################################
+vmcattach simzone_d update_attempts=156,update_frequency=6 nosync
 waitfor 16s
 vmclist
 vmcshow simzone_d update_attempts,update_frequency
 stats
-echo ####################################### [TEST] 476: END vmcattach simzone_d update_attempts=156,update_frequency=6 async #######################################
+echo ####################################### [TEST] 476: END vmcattach simzone_d update_attempts=156,update_frequency=6 nosync #######################################
 echo 
 echo ############################################################ [TEST] 477: START vmcdetach simzone_d #############################################################
 vmcdetach simzone_d
@@ -2302,12 +2302,12 @@ vmclist
 stats
 echo ############################################################# [TEST] 477: END vmcdetach simzone_d ##############################################################
 echo 
-echo ######################################################### [TEST] 478: START vmcdetach simzone_a async ##########################################################
-vmcdetach simzone_a async
+echo ######################################################### [TEST] 478: START vmcdetach simzone_a nosync ##########################################################
+vmcdetach simzone_a nosync
 waitfor 16s
 vmclist
 stats
-echo ########################################################## [TEST] 478: END vmcdetach simzone_a async ###########################################################
+echo ########################################################## [TEST] 478: END vmcdetach simzone_a nosync ###########################################################
 echo 
 echo ############################################################### [TEST] 479: START vmcattach all ################################################################
 vmcattach all
@@ -2340,20 +2340,20 @@ vmcshow simzone_c update_attempts,update_frequency
 stats
 echo ############################################ [TEST] 483: END vmcattach update_attempts=312,update_frequency=12 all #############################################
 echo 
-echo ############################################################ [TEST] 484: START vmcdetach all async #############################################################
-vmcdetach all async
+echo ############################################################ [TEST] 484: START vmcdetach all nosync #############################################################
+vmcdetach all nosync
 waitfor 20s
 vmclist
 stats
-echo ############################################################# [TEST] 484: END vmcdetach all async ##############################################################
+echo ############################################################# [TEST] 484: END vmcdetach all nosync ##############################################################
 echo 
-echo ############################################################ [TEST] 485: START vmcattach all async #############################################################
-vmcattach all async
+echo ############################################################ [TEST] 485: START vmcattach all nosync #############################################################
+vmcattach all nosync
 waitfor 30s
 vmclist
 vmcshow simzone_c update_attempts,update_frequency
 stats
-echo ############################################################# [TEST] 485: END vmcattach all async ##############################################################
+echo ############################################################# [TEST] 485: END vmcattach all nosync ##############################################################
 echo 
 echo ################################################# [TEST] 486: START vmcalter simzone_a replication_vmcs=TESTE ##################################################
 vmcalter simzone_a replication_vmcs=TESTE
@@ -2433,83 +2433,83 @@ vmlist
 stats
 echo ################################################################ [TEST] 500: END vmcapture vm_2 ################################################################
 echo 
-echo ########################################################### [TEST] 501: START vmattach tinyvm async ############################################################
-vmattach tinyvm async
+echo ########################################################### [TEST] 501: START vmattach tinyvm nosync ############################################################
+vmattach tinyvm nosync
 waitfor 1s
 vmlist pending
 waitfor 16s
 vmlist
 stats
-echo ############################################################ [TEST] 501: END vmattach tinyvm async #############################################################
+echo ############################################################ [TEST] 501: END vmattach tinyvm nosync #############################################################
 echo 
-echo ########################################################## [TEST] 502: START vmattach tinyvm async=2 ###########################################################
-vmattach tinyvm async=2
+echo ########################################################## [TEST] 502: START vmattach tinyvm nosync=2 ###########################################################
+vmattach tinyvm nosync=2
 waitfor 1s
 vmlist pending
 waituntil VM ARRIVED=8 increasing 1
 vmlist
 stats
-echo ########################################################### [TEST] 502: END vmattach tinyvm async=2 ############################################################
+echo ########################################################### [TEST] 502: END vmattach tinyvm nosync=2 ############################################################
 echo 
 echo ####################################################### [TEST] 503: START rolealter db2 size=platinum64 ########################################################
 rolealter db2 size=platinum64
 echo ######################################################## [TEST] 503: END rolealter db2 size=platinum64 #########################################################
 echo 
-echo ##################################################### [TEST] 504: START vmattach db2 SUT A:B,X:Y,R:2 async #####################################################
-vmattach db2 SUT A:B,X:Y,R:2 async
+echo ##################################################### [TEST] 504: START vmattach db2 SUT A:B,X:Y,R:2 nosync #####################################################
+vmattach db2 SUT A:B,X:Y,R:2 nosync
 waitfor 1s
 vmlist pending
 waitfor 16s
 vmlist
 vmshow vm_9 role,vmc_name,vmc_pool,host_name,meta_tags,size
 stats
-echo ###################################################### [TEST] 504: END vmattach db2 SUT A:B,X:Y,R:2 async ######################################################
+echo ###################################################### [TEST] 504: END vmattach db2 SUT A:B,X:Y,R:2 nosync ######################################################
 echo 
-echo ############################################### [TEST] 505: START vmattach netclient simhosta2 A:B,X:Y,R:2 async ###############################################
-vmattach netclient simhosta2 A:B,X:Y,R:2 async
+echo ############################################### [TEST] 505: START vmattach netclient simhosta2 A:B,X:Y,R:2 nosync ###############################################
+vmattach netclient simhosta2 A:B,X:Y,R:2 nosync
 waitfor 1s
 vmlist pending
 waitfor 16s
 vmlist
 vmshow vm_10 role,vmc_name,vmc_pool,host_name,meta_tags,size
 stats
-echo ################################################ [TEST] 505: END vmattach netclient simhosta2 A:B,X:Y,R:2 async ################################################
+echo ################################################ [TEST] 505: END vmattach netclient simhosta2 A:B,X:Y,R:2 nosync ################################################
 echo 
-echo ####################################### [TEST] 506: START vmattach fen_hpc auto empty size=platinum64,vmc_pool=LG async ########################################
-vmattach fen_hpc auto empty size=platinum64,vmc_pool=LG async
+echo ####################################### [TEST] 506: START vmattach fen_hpc auto empty size=platinum64,vmc_pool=LG nosync ########################################
+vmattach fen_hpc auto empty size=platinum64,vmc_pool=LG nosync
 waitfor 16s
 vmlist
 vmshow vm_11 vmc_name,vmc_pool,host_name,meta_tags,size
 stats
-echo ######################################## [TEST] 506: END vmattach fen_hpc auto empty size=platinum64,vmc_pool=LG async #########################################
+echo ######################################## [TEST] 506: END vmattach fen_hpc auto empty size=platinum64,vmc_pool=LG nosync #########################################
 echo 
-echo ###################################### [TEST] 507: START vmattach tinyvm auto empty iron32 pause_provision_complete async ######################################
-vmattach tinyvm auto empty iron32 pause_provision_complete async
+echo ###################################### [TEST] 507: START vmattach tinyvm auto empty iron32 pause_provision_complete nosync ######################################
+vmattach tinyvm auto empty iron32 pause_provision_complete nosync
 waitfor 16s
 msgpub VM staging vm_12;continue;something
 waituntil VM ARRIVING=0 decreasing 1
 vmlist
 stats
-echo ####################################### [TEST] 507: END vmattach tinyvm auto empty iron32 pause_provision_complete async #######################################
+echo ####################################### [TEST] 507: END vmattach tinyvm auto empty iron32 pause_provision_complete nosync #######################################
 echo 
 echo ################################################ [TEST] 508: START shell rm -rf /tmp/cb*_was_used_on_execution #################################################
 shell rm -rf /tmp/cb*_was_used_on_execution
 cldalter vm_defaults execute_script_name=~/repos/cloudbench/regression/..//regression/scripts/execute_on_staging.sh
-vmattach tinyvm auto empty iron32 execute_provision_complete async
+vmattach tinyvm auto empty iron32 execute_provision_complete nosync
 waituntil VM ARRIVING=0 decreasing 1
 shell ls /tmp/cb*_was_used_on_execution
 vmlist
 stats
 echo ################################################# [TEST] 508: END shell rm -rf /tmp/cb*_was_used_on_execution ##################################################
 echo 
-echo ############################## [TEST] 509: START vmattach predictablevm auto empty check_boot_started=subscribe_on_starting async ##############################
-vmattach predictablevm auto empty check_boot_started=subscribe_on_starting async
+echo ############################## [TEST] 509: START vmattach predictablevm auto empty check_boot_started=subscribe_on_starting nosync ##############################
+vmattach predictablevm auto empty check_boot_started=subscribe_on_starting nosync
 waitfor 16s
 msgpub VM starting 11111111-1111-1111-1111-111111111111 has started
 waitfor 16s
 vmlist
 stats
-echo ############################### [TEST] 509: END vmattach predictablevm auto empty check_boot_started=subscribe_on_starting async ###############################
+echo ############################### [TEST] 509: END vmattach predictablevm auto empty check_boot_started=subscribe_on_starting nosync ###############################
 echo 
 echo ############################################################## [TEST] 510: START vmattach tinyvm ###############################################################
 vmattach tinyvm
@@ -2613,12 +2613,12 @@ vmlist
 stats
 echo ################################################################ [TEST] 527: END vmdetach vm_4 #################################################################
 echo 
-echo ############################################################ [TEST] 528: START vmdetach vm_5 async #############################################################
-vmdetach vm_5 async
+echo ############################################################ [TEST] 528: START vmdetach vm_5 nosync #############################################################
+vmdetach vm_5 nosync
 waitfor 10s
 vmlist
 stats
-echo ############################################################# [TEST] 528: END vmdetach vm_5 async ##############################################################
+echo ############################################################# [TEST] 528: END vmdetach vm_5 nosync ##############################################################
 echo 
 echo ############################################################## [TEST] 529: START vmdetach oldest ###############################################################
 vmdetach oldest
@@ -2656,12 +2656,12 @@ vmlist
 stats
 echo ############################################################## [TEST] 534: END vmattach willfail ###############################################################
 echo 
-echo ########################################################## [TEST] 535: START vmattach willfail async ###########################################################
-vmattach willfail async
+echo ########################################################## [TEST] 535: START vmattach willfail nosync ###########################################################
+vmattach willfail nosync
 waituntil VM ARRIVING=0 decreasing 1
 vmlist
 stats
-echo ########################################################### [TEST] 535: END vmattach willfail async ############################################################
+echo ########################################################### [TEST] 535: END vmattach willfail nosync ############################################################
 echo 
 echo ############################################################## [TEST] 536: START vmlist finished ###############################################################
 vmlist finished
@@ -2692,14 +2692,14 @@ aialter ai_1 mode=scalable
 aishow ai_1 mode
 echo ########################################################## [TEST] 541: END aialter ai_1 mode=scalable ##########################################################
 echo 
-echo ########################################################### [TEST] 542: START aiattach hadoop async ############################################################
-aiattach hadoop async
+echo ########################################################### [TEST] 542: START aiattach hadoop nosync ############################################################
+aiattach hadoop nosync
 waitfor 30s
 ailist
 vmlist
 aishow ai_2 detach_parallelism,ssh_key_name,sut
 stats
-echo ############################################################ [TEST] 542: END aiattach hadoop async #############################################################
+echo ############################################################ [TEST] 542: END aiattach hadoop nosync #############################################################
 echo 
 echo ############################### [TEST] 543: START aiattach ibm_daytrader detach_parallelism=9,ssh_key_name=AAAABBBBCCCCDDDDEEEE ################################
 aiattach ibm_daytrader detach_parallelism=9,ssh_key_name=AAAABBBBCCCCDDDDEEEE
@@ -2745,14 +2745,14 @@ stateshow
 stats
 echo ################################################################ [TEST] 549: END airestore ai_3 ################################################################
 echo 
-echo ########################### [TEST] 550: START aiattach ibm_daytrader detach_parallelism=10,ssh_key_name=aaaabbbbccccddddeeee async  ############################
-aiattach ibm_daytrader detach_parallelism=10,ssh_key_name=aaaabbbbccccddddeeee async 
+echo ########################### [TEST] 550: START aiattach ibm_daytrader detach_parallelism=10,ssh_key_name=aaaabbbbccccddddeeee nosync  ############################
+aiattach ibm_daytrader detach_parallelism=10,ssh_key_name=aaaabbbbccccddddeeee nosync 
 waitfor 18s
 ailist
 vmlist
 aishow ai_4 detach_parallelism,ssh_key_name,sut
 stats
-echo ############################ [TEST] 550: END aiattach ibm_daytrader detach_parallelism=10,ssh_key_name=aaaabbbbccccddddeeee async  #############################
+echo ############################ [TEST] 550: END aiattach ibm_daytrader detach_parallelism=10,ssh_key_name=aaaabbbbccccddddeeee nosync  #############################
 echo 
 echo ##################################### [TEST] 551: START aiattach netperf netclient_pref_pool=SUT,netclient_size=platinum64 #####################################
 aiattach netperf netclient_pref_pool=SUT,netclient_size=platinum64
@@ -2762,14 +2762,14 @@ aishow ai_5 detach_parallelism,ssh_key_name,sut
 stats
 echo ###################################### [TEST] 551: END aiattach netperf netclient_pref_pool=SUT,netclient_size=platinum64 ######################################
 echo 
-echo ############################ [TEST] 552: START aiattach hadoop hadoopslave_size=platinum64,sut=hadoopmaster->1_x_hadoopslave async #############################
-aiattach hadoop hadoopslave_size=platinum64,sut=hadoopmaster->1_x_hadoopslave async
+echo ############################ [TEST] 552: START aiattach hadoop hadoopslave_size=platinum64,sut=hadoopmaster->1_x_hadoopslave nosync #############################
+aiattach hadoop hadoopslave_size=platinum64,sut=hadoopmaster->1_x_hadoopslave nosync
 waitfor 18s
 ailist
 vmlist
 aishow ai_6 detach_parallelism,ssh_key_name,sut
 stats
-echo ############################# [TEST] 552: END aiattach hadoop hadoopslave_size=platinum64,sut=hadoopmaster->1_x_hadoopslave async ##############################
+echo ############################# [TEST] 552: END aiattach hadoop hadoopslave_size=platinum64,sut=hadoopmaster->1_x_hadoopslave nosync ##############################
 echo 
 echo ############################################################ [TEST] 553: START airesize ai_1 was +1 ############################################################
 airesize ai_1 was +1
@@ -2810,21 +2810,21 @@ vmlist
 stats
 echo ############################################################## [TEST] 557: END vmcapture youngest ##############################################################
 echo 
-echo ########################################################### [TEST] 558: START vmcapture vm_41 async ############################################################
-vmcapture vm_41 async
+echo ########################################################### [TEST] 558: START vmcapture vm_41 nosync ############################################################
+vmcapture vm_41 nosync
 waitfor 25s
 ailist
 vmlist
 stats
-echo ############################################################ [TEST] 558: END vmcapture vm_41 async #############################################################
+echo ############################################################ [TEST] 558: END vmcapture vm_41 nosync #############################################################
 echo 
-echo ########################################################### [TEST] 559: START vmcapture oldest async ###########################################################
-vmcapture oldest async
+echo ########################################################### [TEST] 559: START vmcapture oldest nosync ###########################################################
+vmcapture oldest nosync
 waitfor 25s
 ailist
 vmlist
 stats
-echo ############################################################ [TEST] 559: END vmcapture oldest async ############################################################
+echo ############################################################ [TEST] 559: END vmcapture oldest nosync ############################################################
 echo 
 echo ################################################# [TEST] 560: START aiattach ibm_daytrader load_balancer=true ##################################################
 aiattach ibm_daytrader load_balancer=true
@@ -2883,9 +2883,9 @@ aishow ai_13 load_balancer,sut
 stats
 echo ############################################################ [TEST] 567: END aiattach ibm_daytrader ############################################################
 echo 
-echo ######################################################### [TEST] 568: START aiattach netperf async=4:2 #########################################################
-aiattach netperf async=4:2
-echo ########################################################## [TEST] 568: END aiattach netperf async=4:2 ##########################################################
+echo ######################################################### [TEST] 568: START aiattach netperf nosync=4:2 #########################################################
+aiattach netperf nosync=4:2
+echo ########################################################## [TEST] 568: END aiattach netperf nosync=4:2 ##########################################################
 echo 
 echo #################################################### [TEST] 569: START waituntil AI ARRIVED=17 increasing 2 ####################################################
 waituntil AI ARRIVED=17 increasing 2
@@ -2936,13 +2936,13 @@ vmlist
 stats
 echo ################################################################ [TEST] 575: END aidetach ai_12 ################################################################
 echo 
-echo ############################################################ [TEST] 576: START aidetach ai_13 async ############################################################
-aidetach ai_13 async
+echo ############################################################ [TEST] 576: START aidetach ai_13 nosync ############################################################
+aidetach ai_13 nosync
 waituntil AI RESERVATIONS=16 decreasing 5
 ailist
 vmlist
 stats
-echo ############################################################# [TEST] 576: END aidetach ai_13 async #############################################################
+echo ############################################################# [TEST] 576: END aidetach ai_13 nosync #############################################################
 echo 
 echo ############################################################## [TEST] 577: START aidetach oldest ###############################################################
 aidetach oldest
@@ -2981,13 +2981,13 @@ vmlist
 stats
 echo ############################################################### [TEST] 581: END aicapture oldest ###############################################################
 echo 
-echo ########################################################## [TEST] 582: START aicapture youngest async ##########################################################
-aicapture youngest async
+echo ########################################################## [TEST] 582: START aicapture youngest nosync ##########################################################
+aicapture youngest nosync
 waituntil AI CAPTURING=0
 ailist
 vmlist
 stats
-echo ########################################################### [TEST] 582: END aicapture youngest async ###########################################################
+echo ########################################################### [TEST] 582: END aicapture youngest nosync ###########################################################
 echo 
 echo ############################################################## [TEST] 583: START aidetach random ###############################################################
 aidetach random
@@ -2996,15 +2996,15 @@ vmlist
 stats
 echo ############################################################### [TEST] 583: END aidetach random ################################################################
 echo 
-echo ################################ [TEST] 584: START aiattach ibm_daytrader default default none none pause_all_vms_booted async #################################
-aiattach ibm_daytrader default default none none pause_all_vms_booted async
+echo ################################ [TEST] 584: START aiattach ibm_daytrader default default none none pause_all_vms_booted nosync #################################
+aiattach ibm_daytrader default default none none pause_all_vms_booted nosync
 waitfor 40s
 msgpub VM staging ai_26;continue;something
 waituntil AI ARRIVING=0 decreasing 1
 ailist
 vmlist
 stats
-echo ################################# [TEST] 584: END aiattach ibm_daytrader default default none none pause_all_vms_booted async ##################################
+echo ################################# [TEST] 584: END aiattach ibm_daytrader default default none none pause_all_vms_booted nosync ##################################
 echo 
 echo ################################################ [TEST] 585: START shell rm -rf /tmp/cb*_was_used_on_execution #################################################
 shell rm -rf /tmp/cb*_was_used_on_execution
@@ -3162,12 +3162,12 @@ stats
 vmlist
 echo ########################################################### [TEST] 607: END vmmigrate youngest dest ############################################################
 echo 
-echo ###################################################### [TEST] 608: START vmmigrate youngest source async #######################################################
-vmmigrate youngest source async
+echo ###################################################### [TEST] 608: START vmmigrate youngest source nosync #######################################################
+vmmigrate youngest source nosync
 waitfor 10s
 stats
 vmlist
-echo ####################################################### [TEST] 608: END vmmigrate youngest source async ########################################################
+echo ####################################################### [TEST] 608: END vmmigrate youngest source nosync ########################################################
 echo 
 echo ########################################################## [TEST] 609: START vmprotect youngest dest ###########################################################
 vmprotect youngest dest
@@ -3175,12 +3175,12 @@ stats
 vmlist
 echo ########################################################### [TEST] 609: END vmprotect youngest dest ############################################################
 echo 
-echo ###################################################### [TEST] 610: START vmprotect youngest source async #######################################################
-vmprotect youngest source async
+echo ###################################################### [TEST] 610: START vmprotect youngest source nosync #######################################################
+vmprotect youngest source nosync
 waitfor 10s
 stats
 vmlist
-echo ####################################################### [TEST] 610: END vmprotect youngest source async ########################################################
+echo ####################################################### [TEST] 610: END vmprotect youngest source nosync ########################################################
 echo 
 echo ############################################################# [TEST] 611: START reserved for vmcrs #############################################################
 reserved for vmcrs

--- a/regression/regression_test_tests.txt
+++ b/regression/regression_test_tests.txt
@@ -195,18 +195,18 @@ stats TESTCLOUD
 waitfor TESTCLOUD 10s
 vmcattach TESTCLOUD simzone_a\; vmclist TESTCLOUD\; vmcshow TESTCLOUD simzone_a\; stats TESTCLOUD
 vmccleanup TESTCLOUD simzone_a
-vmcattach TESTCLOUD simzone_b async\; waitfor TESTCLOUD 16s\; vmclist TESTCLOUD\; vmcshow TESTCLOUD simzone_b update_attempts,update_frequency\; stats TESTCLOUD
+vmcattach TESTCLOUD simzone_b nosync\; waitfor TESTCLOUD 16s\; vmclist TESTCLOUD\; vmcshow TESTCLOUD simzone_b update_attempts,update_frequency\; stats TESTCLOUD
 vmcattach TESTCLOUD simzone_c update_attempts=78,update_frequency=3\; vmclist TESTCLOUD\; vmcshow TESTCLOUD simzone_c update_attempts,update_frequency\; stats TESTCLOUD
-vmcattach TESTCLOUD simzone_d update_attempts=156,update_frequency=6 async\; waitfor TESTCLOUD 16s\; vmclist TESTCLOUD\; vmcshow TESTCLOUD simzone_d update_attempts,update_frequency\; stats TESTCLOUD
+vmcattach TESTCLOUD simzone_d update_attempts=156,update_frequency=6 nosync\; waitfor TESTCLOUD 16s\; vmclist TESTCLOUD\; vmcshow TESTCLOUD simzone_d update_attempts,update_frequency\; stats TESTCLOUD
 vmcdetach TESTCLOUD simzone_d\; vmcdetach TESTCLOUD simzone_c\; vmcdetach TESTCLOUD simzone_b\; vmclist TESTCLOUD\; stats TESTCLOUD
-vmcdetach TESTCLOUD simzone_a async\; waitfor TESTCLOUD 16s\; vmclist TESTCLOUD\; stats TESTCLOUD
+vmcdetach TESTCLOUD simzone_a nosync\; waitfor TESTCLOUD 16s\; vmclist TESTCLOUD\; stats TESTCLOUD
 vmcattach TESTCLOUD all\; vmclist TESTCLOUD\; stats TESTCLOUD
 vmcattach TESTCLOUD all\; vmclist TESTCLOUD\; stats TESTCLOUD
 vmcdetach TESTCLOUD simzone_a\; vmclist TESTCLOUD\; stats TESTCLOUD
 vmcdetach TESTCLOUD all\; vmclist TESTCLOUD\; stats TESTCLOUD
 vmcattach TESTCLOUD update_attempts=312,update_frequency=12 all\; vmclist TESTCLOUD\; vmcshow TESTCLOUD simzone_c update_attempts,update_frequency\; stats TESTCLOUD
-vmcdetach TESTCLOUD all async\; waitfor TESTCLOUD 20s\; vmclist TESTCLOUD\; stats TESTCLOUD
-vmcattach TESTCLOUD all async\; waitfor TESTCLOUD 30s\; vmclist TESTCLOUD\; vmcshow TESTCLOUD simzone_c update_attempts,update_frequency\; stats TESTCLOUD
+vmcdetach TESTCLOUD all nosync\; waitfor TESTCLOUD 20s\; vmclist TESTCLOUD\; stats TESTCLOUD
+vmcattach TESTCLOUD all nosync\; waitfor TESTCLOUD 30s\; vmclist TESTCLOUD\; vmcshow TESTCLOUD simzone_c update_attempts,update_frequency\; stats TESTCLOUD
 vmcalter TESTCLOUD simzone_a replication_vmcs=TESTE\; vmcshow TESTCLOUD simzone_a replication_vmcs
 hostlist TESTCLOUD
 hostshow TESTCLOUD simhosta3 all
@@ -222,15 +222,15 @@ vmattach TESTCLOUD tinyvm simhostb1\; vmlist TESTCLOUD\; vmshow TESTCLOUD vm_3 v
 vmattach TESTCLOUD db2 auto a:b,x:y,r:2\; vmlist TESTCLOUD\; vmshow TESTCLOUD vm_4 vmc_name,vmc_pool,host_name,meta_tags,size\; stats TESTCLOUD
 vmattach TESTCLOUD netclient auto a:b,x:y,r:2 size=platinum64,vmc_pool=SUT\; vmlist TESTCLOUD\; vmshow TESTCLOUD vm_5 vmc_name,vmc_pool,host_name,meta_tags,size\; stats TESTCLOUD
 vmcapture TESTCLOUD vm_2\; vmlist TESTCLOUD\; stats TESTCLOUD
-vmattach TESTCLOUD tinyvm async\; waitfor TESTCLOUD 1s\; vmlist TESTCLOUD pending\; waitfor TESTCLOUD 16s\; vmlist TESTCLOUD\; stats TESTCLOUD
-vmattach TESTCLOUD tinyvm async=2\; waitfor TESTCLOUD 1s\; vmlist TESTCLOUD pending\; waituntil TESTCLOUD VM ARRIVED=8 increasing 1\; vmlist TESTCLOUD\; stats TESTCLOUD
+vmattach TESTCLOUD tinyvm nosync\; waitfor TESTCLOUD 1s\; vmlist TESTCLOUD pending\; waitfor TESTCLOUD 16s\; vmlist TESTCLOUD\; stats TESTCLOUD
+vmattach TESTCLOUD tinyvm nosync=2\; waitfor TESTCLOUD 1s\; vmlist TESTCLOUD pending\; waituntil TESTCLOUD VM ARRIVED=8 increasing 1\; vmlist TESTCLOUD\; stats TESTCLOUD
 rolealter TESTCLOUD db2 size=platinum64
-vmattach TESTCLOUD db2 SUT A:B,X:Y,R:2 async\; waitfor TESTCLOUD 1s\; vmlist TESTCLOUD pending\; waitfor TESTCLOUD 16s\; vmlist TESTCLOUD\; vmshow TESTCLOUD vm_9 role,vmc_name,vmc_pool,host_name,meta_tags,size\; stats TESTCLOUD
-vmattach TESTCLOUD netclient simhosta2 A:B,X:Y,R:2 async\; waitfor TESTCLOUD 1s\; vmlist TESTCLOUD pending\; waitfor TESTCLOUD 16s\; vmlist TESTCLOUD\; vmshow TESTCLOUD vm_10 role,vmc_name,vmc_pool,host_name,meta_tags,size\; stats TESTCLOUD
-vmattach TESTCLOUD fen_hpc auto empty size=platinum64,vmc_pool=LG async\; waitfor TESTCLOUD 16s\; vmlist TESTCLOUD\; vmshow TESTCLOUD vm_11 vmc_name,vmc_pool,host_name,meta_tags,size\; stats TESTCLOUD
-vmattach TESTCLOUD tinyvm auto empty iron32 pause_provision_complete async\; waitfor TESTCLOUD 16s\; msgpub TESTCLOUD VM staging vm_12;continue;something\; waituntil TESTCLOUD VM ARRIVING=0 decreasing 1\; vmlist TESTCLOUD\; stats TESTCLOUD
-shell TESTCLOUD rm -rf /tmp/cb*_was_used_on_execution\; cldalter TESTCLOUD vm_defaults execute_script_name=CB_DIRECTORY/regression/scripts/execute_on_staging.sh\; vmattach TESTCLOUD tinyvm auto empty iron32 execute_provision_complete async\; waituntil TESTCLOUD VM ARRIVING=0 decreasing 1\; shell TESTCLOUD ls /tmp/cb*_was_used_on_execution\; vmlist TESTCLOUD\; stats TESTCLOUD
-vmattach TESTCLOUD predictablevm auto empty check_boot_started=subscribe_on_starting async\; waitfor TESTCLOUD 16s\; msgpub TESTCLOUD VM starting 11111111-1111-1111-1111-111111111111 has started\; waitfor TESTCLOUD 16s\; vmlist TESTCLOUD\; stats TESTCLOUD
+vmattach TESTCLOUD db2 SUT A:B,X:Y,R:2 nosync\; waitfor TESTCLOUD 1s\; vmlist TESTCLOUD pending\; waitfor TESTCLOUD 16s\; vmlist TESTCLOUD\; vmshow TESTCLOUD vm_9 role,vmc_name,vmc_pool,host_name,meta_tags,size\; stats TESTCLOUD
+vmattach TESTCLOUD netclient simhosta2 A:B,X:Y,R:2 nosync\; waitfor TESTCLOUD 1s\; vmlist TESTCLOUD pending\; waitfor TESTCLOUD 16s\; vmlist TESTCLOUD\; vmshow TESTCLOUD vm_10 role,vmc_name,vmc_pool,host_name,meta_tags,size\; stats TESTCLOUD
+vmattach TESTCLOUD fen_hpc auto empty size=platinum64,vmc_pool=LG nosync\; waitfor TESTCLOUD 16s\; vmlist TESTCLOUD\; vmshow TESTCLOUD vm_11 vmc_name,vmc_pool,host_name,meta_tags,size\; stats TESTCLOUD
+vmattach TESTCLOUD tinyvm auto empty iron32 pause_provision_complete nosync\; waitfor TESTCLOUD 16s\; msgpub TESTCLOUD VM staging vm_12;continue;something\; waituntil TESTCLOUD VM ARRIVING=0 decreasing 1\; vmlist TESTCLOUD\; stats TESTCLOUD
+shell TESTCLOUD rm -rf /tmp/cb*_was_used_on_execution\; cldalter TESTCLOUD vm_defaults execute_script_name=CB_DIRECTORY/regression/scripts/execute_on_staging.sh\; vmattach TESTCLOUD tinyvm auto empty iron32 execute_provision_complete nosync\; waituntil TESTCLOUD VM ARRIVING=0 decreasing 1\; shell TESTCLOUD ls /tmp/cb*_was_used_on_execution\; vmlist TESTCLOUD\; stats TESTCLOUD
+vmattach TESTCLOUD predictablevm auto empty check_boot_started=subscribe_on_starting nosync\; waitfor TESTCLOUD 16s\; msgpub TESTCLOUD VM starting 11111111-1111-1111-1111-111111111111 has started\; waitfor TESTCLOUD 16s\; vmlist TESTCLOUD\; stats TESTCLOUD
 vmattach TESTCLOUD tinyvm\; vmlist TESTCLOUD\; stats TESTCLOUD
 vmattach TESTCLOUD tinyvm\; vmlist TESTCLOUD\; stats TESTCLOUD
 vmattach TESTCLOUD tinyvm\; vmlist TESTCLOUD\; stats TESTCLOUD
@@ -249,21 +249,21 @@ vmrepair TESTCLOUD vm_3\; stateshow TESTCLOUD\; stats TESTCLOUD
 vmsave TESTCLOUD vm_3\; stateshow TESTCLOUD\; stats TESTCLOUD
 vmrestore TESTCLOUD vm_3\; stateshow TESTCLOUD\; stats TESTCLOUD
 vmdetach TESTCLOUD vm_4\; vmlist TESTCLOUD\; stats TESTCLOUD
-vmdetach TESTCLOUD vm_5 async\; waitfor TESTCLOUD 10s\; vmlist TESTCLOUD\; stats TESTCLOUD
+vmdetach TESTCLOUD vm_5 nosync\; waitfor TESTCLOUD 10s\; vmlist TESTCLOUD\; stats TESTCLOUD
 vmdetach TESTCLOUD oldest\; vmlist TESTCLOUD\; stats TESTCLOUD
 vmdetach TESTCLOUD youngest\; vmlist TESTCLOUD\; stats TESTCLOUD
 vmdetach TESTCLOUD random\; vmlist TESTCLOUD\; stats TESTCLOUD
 vmdetach TESTCLOUD all\; vmlist TESTCLOUD\; stats TESTCLOUD
 vmattach TESTCLOUD norole\; vmlist TESTCLOUD\; stats TESTCLOUD
 vmattach TESTCLOUD willfail\; vmlist TESTCLOUD\; stats TESTCLOUD
-vmattach TESTCLOUD willfail async\; waituntil TESTCLOUD VM ARRIVING=0 decreasing 1\; vmlist TESTCLOUD\; stats TESTCLOUD
+vmattach TESTCLOUD willfail nosync\; waituntil TESTCLOUD VM ARRIVING=0 decreasing 1\; vmlist TESTCLOUD\; stats TESTCLOUD
 vmlist TESTCLOUD finished
 vmlist TESTCLOUD failed 
 aiattach TESTCLOUD ibm_daytrader\; ailist TESTCLOUD\; vmlist TESTCLOUD\; aishow TESTCLOUD ai_1 detach_parallelism,ssh_key_name,sut\; stats TESTCLOUD
 ailist TESTCLOUD
 aishow TESTCLOUD ai_1 all
 aialter TESTCLOUD ai_1 mode=scalable\; aishow TESTCLOUD ai_1 mode
-aiattach TESTCLOUD hadoop async\; waitfor TESTCLOUD 30s\; ailist TESTCLOUD\; vmlist TESTCLOUD\; aishow TESTCLOUD ai_2 detach_parallelism,ssh_key_name,sut\; stats TESTCLOUD
+aiattach TESTCLOUD hadoop nosync\; waitfor TESTCLOUD 30s\; ailist TESTCLOUD\; vmlist TESTCLOUD\; aishow TESTCLOUD ai_2 detach_parallelism,ssh_key_name,sut\; stats TESTCLOUD
 aiattach TESTCLOUD ibm_daytrader detach_parallelism=9,ssh_key_name=AAAABBBBCCCCDDDDEEEE\; ailist TESTCLOUD\; vmlist TESTCLOUD\; aishow TESTCLOUD ai_3 detach_parallelism,ssh_key_name,sut\; stats TESTCLOUD
 airunstate TESTCLOUD ai_3 suspend\; stateshow TESTCLOUD\; stats TESTCLOUD
 airunstate TESTCLOUD ai_3 attached\; stateshow TESTCLOUD\; stats TESTCLOUD
@@ -271,16 +271,16 @@ aifail TESTCLOUD ai_3\; stateshow TESTCLOUD\; stats TESTCLOUD
 airepair TESTCLOUD ai_3\; stateshow TESTCLOUD\; stats TESTCLOUD
 aisave TESTCLOUD ai_3\; stateshow TESTCLOUD\; stats TESTCLOUD
 airestore TESTCLOUD ai_3\; stateshow TESTCLOUD\; stats TESTCLOUD
-aiattach TESTCLOUD ibm_daytrader detach_parallelism=10,ssh_key_name=aaaabbbbccccddddeeee async \; waitfor TESTCLOUD 18s\; ailist TESTCLOUD\; vmlist TESTCLOUD\; aishow TESTCLOUD ai_4 detach_parallelism,ssh_key_name,sut\; stats TESTCLOUD
+aiattach TESTCLOUD ibm_daytrader detach_parallelism=10,ssh_key_name=aaaabbbbccccddddeeee nosync \; waitfor TESTCLOUD 18s\; ailist TESTCLOUD\; vmlist TESTCLOUD\; aishow TESTCLOUD ai_4 detach_parallelism,ssh_key_name,sut\; stats TESTCLOUD
 aiattach TESTCLOUD netperf netclient_pref_pool=SUT,netclient_size=platinum64\; ailist TESTCLOUD\; vmlist TESTCLOUD\; aishow TESTCLOUD ai_5 detach_parallelism,ssh_key_name,sut\; stats TESTCLOUD
-aiattach TESTCLOUD hadoop hadoopslave_size=platinum64,sut=hadoopmaster->1_x_hadoopslave async\; waitfor TESTCLOUD 18s\; ailist TESTCLOUD\; vmlist TESTCLOUD\; aishow TESTCLOUD ai_6 detach_parallelism,ssh_key_name,sut\; stats TESTCLOUD
+aiattach TESTCLOUD hadoop hadoopslave_size=platinum64,sut=hadoopmaster->1_x_hadoopslave nosync\; waitfor TESTCLOUD 18s\; ailist TESTCLOUD\; vmlist TESTCLOUD\; aishow TESTCLOUD ai_6 detach_parallelism,ssh_key_name,sut\; stats TESTCLOUD
 airesize TESTCLOUD ai_1 was +1\; ailist TESTCLOUD\; vmlist TESTCLOUD\; aishow TESTCLOUD ai_1 detach_parallelism,ssh_key_name,sut\; stats TESTCLOUD
 airesize TESTCLOUD ai_1 was -1\; ailist TESTCLOUD\; vmlist TESTCLOUD\; aishow TESTCLOUD ai_1 detach_parallelism,ssh_key_name,sut\; stats TESTCLOUD
 aiattach TESTCLOUD ibm_daytrader\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
 vmcapture TESTCLOUD vm_29\; stats TESTCLOUD\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
 vmcapture TESTCLOUD youngest\; stats TESTCLOUD\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
-vmcapture TESTCLOUD vm_41 async\; waitfor TESTCLOUD 25s\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
-vmcapture TESTCLOUD oldest async\; waitfor TESTCLOUD 25s\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
+vmcapture TESTCLOUD vm_41 nosync\; waitfor TESTCLOUD 25s\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
+vmcapture TESTCLOUD oldest nosync\; waitfor TESTCLOUD 25s\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
 aiattach TESTCLOUD ibm_daytrader load_balancer=true\; ailist TESTCLOUD\; vmlist TESTCLOUD\; aishow TESTCLOUD ai_8 load_balancer,sut\; stats TESTCLOUD
 aiattach TESTCLOUD ibm_daytrader\; ailist TESTCLOUD\; vmlist TESTCLOUD\; aishow TESTCLOUD ai_9 load_balancer,sut\; stats TESTCLOUD
 aiattach TESTCLOUD ibm_daytrader\; ailist TESTCLOUD\; vmlist TESTCLOUD\; aishow TESTCLOUD ai_10 load_balancer,sut\; stats TESTCLOUD
@@ -289,7 +289,7 @@ typeshow TESTCLOUD ibm_daytrader
 typealter TESTCLOUD ibm_daytrader load_balancer=true\; typeshow TESTCLOUD ibm_daytrader
 aiattach TESTCLOUD ibm_daytrader\; ailist TESTCLOUD\; vmlist TESTCLOUD\; aishow TESTCLOUD ai_12 load_balancer,sut\; stats TESTCLOUD
 aiattach TESTCLOUD ibm_daytrader\; ailist TESTCLOUD\; vmlist TESTCLOUD\; aishow TESTCLOUD ai_13 load_balancer,sut\; stats TESTCLOUD
-aiattach TESTCLOUD netperf async=4:2
+aiattach TESTCLOUD netperf nosync=4:2
 waituntil TESTCLOUD AI ARRIVED=17 increasing 2\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
 aiattach TESTCLOUD ibm_daytrader\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
 aiattach TESTCLOUD ibmderby_tradelite\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
@@ -297,15 +297,15 @@ aiattach TESTCLOUD hpcc\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
 aiattach TESTCLOUD coremark\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
 aiattach TESTCLOUD filebench\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
 aidetach TESTCLOUD ai_12\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
-aidetach TESTCLOUD ai_13 async\; waituntil TESTCLOUD AI RESERVATIONS=16 decreasing 5\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
+aidetach TESTCLOUD ai_13 nosync\; waituntil TESTCLOUD AI RESERVATIONS=16 decreasing 5\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
 aidetach TESTCLOUD oldest\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
 aidetach TESTCLOUD youngest\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
 aiattach TESTCLOUD ibm_daytrader\; aiattach TESTCLOUD netperf\; aiattach TESTCLOUD hpcc\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
 aicapture TESTCLOUD ai_10\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
 aicapture TESTCLOUD oldest\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
-aicapture TESTCLOUD youngest async\; waituntil TESTCLOUD AI CAPTURING=0\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
+aicapture TESTCLOUD youngest nosync\; waituntil TESTCLOUD AI CAPTURING=0\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
 aidetach TESTCLOUD random\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
-aiattach TESTCLOUD ibm_daytrader default default none none pause_all_vms_booted async\; waitfor TESTCLOUD 40s\; msgpub TESTCLOUD VM staging ai_26;continue;something\; waituntil TESTCLOUD AI ARRIVING=0 decreasing 1\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
+aiattach TESTCLOUD ibm_daytrader default default none none pause_all_vms_booted nosync\; waitfor TESTCLOUD 40s\; msgpub TESTCLOUD VM staging ai_26;continue;something\; waituntil TESTCLOUD AI ARRIVING=0 decreasing 1\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
 shell TESTCLOUD rm -rf /tmp/cb*_was_used_on_execution\; cldalter TESTCLOUD ai_defaults execute_script_name=CB_DIRECTORY/regression/scripts/execute_on_staging.sh\; aiattach TESTCLOUD ibm_daytrader default default none none execute_all_vms_booted\; shell TESTCLOUD ls /tmp/cb*_was_used_on_execution\; waitfor TESTCLOUD 25s\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD
 aiattach TESTCLOUD hadoop save_on_attach=true\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD\; stateshow TESTCLOUD
 airestore TESTCLOUD ai_28\; ailist TESTCLOUD\; vmlist TESTCLOUD\; stats TESTCLOUD\; stateshow TESTCLOUD
@@ -329,9 +329,9 @@ aidrsdetach TESTCLOUD all\; aidetach TESTCLOUD all\; aidrslist TESTCLOUD\; ailis
 vmcattach TESTCLOUD simzone_source initial_hosts=source\; hostlist TESTCLOUD\; vmcattach TESTCLOUD simzone_dest initial_hosts=dest\; hostlist TESTCLOUD
 vmattach TESTCLOUD tinyvm simzone_source\; stats TESTCLOUD\; vmlist TESTCLOUD
 vmmigrate TESTCLOUD youngest dest\; stats TESTCLOUD\; vmlist TESTCLOUD
-vmmigrate TESTCLOUD youngest source async\; waitfor TESTCLOUD 10s\; stats TESTCLOUD\; vmlist TESTCLOUD
+vmmigrate TESTCLOUD youngest source nosync\; waitfor TESTCLOUD 10s\; stats TESTCLOUD\; vmlist TESTCLOUD
 vmprotect TESTCLOUD youngest dest\; stats TESTCLOUD\; vmlist TESTCLOUD
-vmprotect TESTCLOUD youngest source async\; waitfor TESTCLOUD 10s\; stats TESTCLOUD\; vmlist TESTCLOUD
+vmprotect TESTCLOUD youngest source nosync\; waitfor TESTCLOUD 10s\; stats TESTCLOUD\; vmlist TESTCLOUD
 reserved for vmcrs
 reserved for vmcrs
 reserved for vmcrs

--- a/scenarios/common.py
+++ b/scenarios/common.py
@@ -533,18 +533,18 @@ def deploy_vapp(options, api, workload, hostpair = None, nr_ais = "1", \
     _temp_attr_list_str = _temp_attr_list_str[0:-1]
     
     if int(inter_vm_wait) :
-        _async = nr_ais + ':' + inter_vm_wait
+        _nosync = nr_ais + ':' + inter_vm_wait
     else :
-        _async = nr_ais
+        _nosync = nr_ais
 
     if nr_ais == "1" :
         _max_check = False
-        _async = False
+        _nosync = False
     else :
         _max_check = max_check
-        _async = nr_ais
+        _nosync = nr_ais
         
-    _app_attr = api.appattach(options.cloud_name, workload, pause_step = script_execution, temp_attr_list = _temp_attr_list_str, async = _async)
+    _app_attr = api.appattach(options.cloud_name, workload, pause_step = script_execution, temp_attr_list = _temp_attr_list_str, nosync = _nosync)
 
     if max_check :
 

--- a/scenarios/instance_provision_capacity.py
+++ b/scenarios/instance_provision_capacity.py
@@ -816,7 +816,7 @@ def capacity_phase(api, options, performance_data, directory) :
             api.vmattach(options.cloud_name, options.role, \
                          size = options.instance_size, \
                          temp_attr_list = _temp_attr_list_str, \
-                         async = _selected_batch_size, \
+                         nosync = _selected_batch_size, \
                          pause_step = options.pause_step)
                         
         else :

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setuptools.setup(
           'python-dateutil',
           'pillow',
           'jsonschema',
-          'mysql-connector'
+          'mysql-connector',
+          'distro'
       ],
 )


### PR DESCRIPTION
I believe I've converted everything and also included
command-line-level backwards compatibility (only) for 'async',
just because old habits die hard.

But, anything that uses the API will need to switchover.