### PR TITLE
Fix dependencies Checker

### DIFF
--- a/lib/auxiliary/dependencies.py
+++ b/lib/auxiliary/dependencies.py
@@ -48,7 +48,7 @@ except ModuleNotFoundError as e:
             "Version: %s" % platform.python_version()
         )
         cberr(_msg)
-        raise Exception(e)
+        raise e
     pass
 
 def deps_file_parser(depsdict, username, options, hostname, process_manager = False) :

--- a/lib/auxiliary/dependencies.py
+++ b/lib/auxiliary/dependencies.py
@@ -24,6 +24,7 @@
     @author: Marcio A. Silva, Michael R. Galaxy
 '''
 from sys import path
+import sys
 import os
 import re
 import platform
@@ -37,6 +38,18 @@ from lib.remote.process_management import ProcessManagement
 from lib.auxiliary.data_ops import cmp
 from lib.auxiliary.code_instrumentation import  VerbosityFilter, MsgFilter, cbdebug, cberr, cbwarn, cbinfo, cbcrit
 from lib.remote.network_functions import check_url
+
+try:
+    import distro
+except ModuleNotFoundError as e:
+    if sys.version_info.major > 2 and sys.version_info.minor >= 7:
+        _msg = (
+            "Python version 3.7 and higher require `distro` package to be installed. "
+            "Version: %s" % platform.python_version()
+        )
+        cberr(_msg)
+        raise Exception(e)
+    pass
 
 def deps_file_parser(depsdict, username, options, hostname, process_manager = False) :
     '''
@@ -274,7 +287,13 @@ def get_linux_distro() :
     '''
     TBD
     '''
-    _linux_distro_kind, _linux_distro_ver, _linux_distro_name = platform.linux_distribution()
+    try:
+        _linux_distro_kind, _linux_distro_ver, _linux_distro_name = platform.linux_distribution()
+    except AttributeError:
+        _linux_distro_kind = distro.name()
+        _linux_distro_ver = distro.version()
+        _linux_distro_name = distro.id()
+
     if _linux_distro_kind.count("Red Hat") :
         _linux_distro_kind = "rhel"
     elif _linux_distro_kind.count("Scientific Linux") :

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setuptools.setup(
           'python-dateutil',
           'pillow',
           'jsonschema',
-          'mysql-connector'
+          'mysql-connector',
+          'distro'
       ],
 )


### PR DESCRIPTION
Hello @mraygalaxy! I work with @jdesfossez at DigitalOcean. During some testing of `cbtool` on Python3.8, ran into an issue with the dependencies checker. As it turns out the `linux_distribution()` method was removed from the `platform` module in the standard lib in Python3.7.

Related Python Bugs (discussion about removing the method):

* https://bugs.python.org/issue1322
* https://bugs.python.org/issue28167

* Try to import `distro`. If version below 3.7, pass, else, raise
exception. `distro` is a requirement for Python >= 3.7
* Try to use `platform.linux_distribution()`. If an `AttributeError` is
raised (indicating the `linux_distribution` method is no longer
available), use `distro.name()`, `distro.version()`, `distro.id()` to
obtain the same information from the `distro` package.
* Include `distro` in `setup.py` to cover package installation.