### PR TITLE
Fix coremark

### DIFF
--- a/configs/templates/internal_options.txt
+++ b/configs/templates/internal_options.txt
@@ -662,6 +662,7 @@ MYSQL = imageids:1, imageid1:ubuntu_cb_sysbench
 BONNIE = imageids:1, imageid1:ubuntu_cb_bonnie
 LINPACK = imageids:1, imageid1:ubuntu_cb_linpack
 KERNBENCH = imageids:1, imageid1:ubuntu_cb_kernbench
+COREMARK = imageids:1, imageid1:ubuntu_cb_coremark
 LB = imageids:1, imageid1:ubuntu_cb_nullworkload
 TPCC = imageids:1, imageid1:ubuntu_cb_tpcc
 STRESS = imageids:1, imageid1:ubuntu_cb_stress

--- a/scripts/coremark/cb_run_coremark.sh
+++ b/scripts/coremark/cb_run_coremark.sh
@@ -23,6 +23,7 @@ set_load_gen $@
 
 LOAD_GENERATOR_TARGET_IP=`get_my_ai_attribute load_generator_target_ip`
 LOAD_FACTOR=`get_my_ai_attribute_with_default load_factor 10000`
+MALLOC_OVERRIDE=`get_my_ai_attribute_with_default malloc_override 4000`
 coremark=`which coremark`
 
 declare -A CMDLINE_START
@@ -30,7 +31,7 @@ declare -A CMDLINE_START
 CMDLINE_PARAMS_SEEDS="0x3415 0x3415 0x66"
 
 CMDLINE_PARAMS_ITERATIONS=$((${LOAD_LEVEL}*${LOAD_FACTOR}))
-CMDLINE_PARAMS_INTERNAL="7 1 4000"
+CMDLINE_PARAMS_INTERNAL="7 1 ${MALLOC_OVERRIDE}"
 
 CMDLINE="$coremark ${CMDLINE_PARAMS_SEEDS} ${CMDLINE_PARAMS_ITERATIONS} ${CMDLINE_PARAMS_INTERNAL}"
 

--- a/scripts/coremark/cb_setup_cmk.sh
+++ b/scripts/coremark/cb_setup_cmk.sh
@@ -48,9 +48,9 @@ then
     sudo sed -i 's/CFLAGS +=/CFLAGS += -lpthread/g' Makefile
 fi
 
-COMMON_PARMS="PORT_DIR=linux64 ITERATIONS=100 REBUILD=1"
+COMMON_PARMS="PORT_DIR=linux ITERATIONS=100 REBUILD=1"
 
-make LDFLAGS="-L /lib64 -l pthread" XCFLAGS="-DMULTITHREAD=${NR_THREADS} -DUSE_PTHREAD" $COMMON_PARMS
+make LDFLAGS="-L /lib64 -l pthread" XCFLAGS="-DMULTITHREAD=${NR_THREADS} -DUSE_PTHREAD -pthread" $COMMON_PARMS
 
 if [[ $? -ne 0 ]]
 then

--- a/scripts/coremark/virtual_application.txt
+++ b/scripts/coremark/virtual_application.txt
@@ -42,6 +42,7 @@ COREMARK_START1 = cb_run_coremark.sh
 # VApp-specific modifier parameters. Commented attributes imply default values assumed
 LOAD_FACTOR = 10000
 THREADS_PER_CPU = 2
+MALLOC_OVERRIDE = 4000
 
 # Inter-Virtual Application instances (inter-AI) synchronized execution. Entirely optional
 #SYNC_COUNTER_NAME = synchronization_counter


### PR DESCRIPTION
A couple of changes needed to make coremark usable on a recent Ubuntu and have the input buffer configurable.