### PR TITLE
Linode followup bugfixes

### DIFF
--- a/lib/operations/active_operations.py
+++ b/lib/operations/active_operations.py
@@ -2540,7 +2540,7 @@ class ActiveObjectOperations(BaseObjectOperations) :
                 _rcmd = "rsync -e \"" + _proc_man.rsync_conn + "\""
                 _rcmd += " --exclude-from "
                 _rcmd += "'" +  obj_attr_list["exclude_list"] + "' -az "
-                _rcmd += "--delete --no-o --no-g --inplace --rsync-path='sudo rsync' -O " 
+                _rcmd += "--delete --no-o --no-g --inplace -O "
                 _rcmd += obj_attr_list["base_dir"] + "/* " 
                 _rcmd += obj_attr_list["prov_cloud_ip"] + ":~/" 
                 _rcmd += obj_attr_list["remote_dir_name"] + '/'


### PR DESCRIPTION
1. Linode doesn't have the same power-on command as other clouds, so handle that better. We have a policy in cloudbench that we do not destroy offline instances (for evidence purposes, in case a VM or host was broken and needs to be investigated), so this is an important command.

2. I want to revert this commit from 2018:

commit 751de25fba78c99ed4db0b24d146a48fc9371a98
Date:   Fri Mar 2 10:12:37 2018 -0500

If we keep this commit, it causes our files to be owned by root inside the running containers instead of being owned by 'cbuser' and we're not able to startup successfully.