### PR TITLE
Update workloads to 22.04

### DIFF
--- a/docker/build_common.sh
+++ b/docker/build_common.sh
@@ -61,7 +61,7 @@ else
     echo "##### rsync server was found on ${CB_RSYNC}"  
 fi
 
-CB_UBUNTU_BASE=ubuntu:18.04
+CB_UBUNTU_BASE=ubuntu:22.04
 CB_CENTOS_BASE=centos:7
 CB_VERB="-q"
 CB_PUSH="nopush"

--- a/docker/workload/Dockerfile-ubuntu-cb_stress
+++ b/docker/workload/Dockerfile-ubuntu-cb_stress
@@ -1,0 +1,8 @@
+FROM REPLACE_NULLWORKLOAD_UBUNTU
+
+# stress-install-pm
+RUN apt-get update
+RUN apt-get install -y stress-ng
+# stress-install-pm
+
+RUN chown -R REPLACE_USERNAME:REPLACE_USERNAME /home/REPLACE_USERNAME

--- a/docker/workload/Dockerfile-ubuntu_cb_linpack
+++ b/docker/workload/Dockerfile-ubuntu_cb_linpack
@@ -2,9 +2,8 @@ FROM REPLACE_NULLWORKLOAD_UBUNTU
 
 # linpack-install-man
 RUN mkdir -p /home/REPLACE_USERNAME/linpack/benchmarks/linpack; sudo chown -R REPLACE_USERNAME:REPLACE_USERNAME /home/REPLACE_USERNAME/linpack/
-RUN wget -N -v -P /home/REPLACE_USERNAME/linpack http://registrationcenter.intel.com/irc_nas/7615/l_lpk_p_11.3.0.004.tgz
-#RUN REPLACE_RSYNC/l_lpk_p_11.3.0.004.tgz /home/REPLACE_USERNAME/linpack/
-RUN cd /home/REPLACE_USERNAME/linpack/; sudo tar -xzvf l_lpk_p_11.3.0.004.tgz
+RUN wget -N -v -P /home/REPLACE_USERNAME/linpack https://downloadmirror.intel.com/781888/l_onemklbench_p_2023.2.0_49340.tgz
+RUN cd /home/REPLACE_USERNAME/linpack/; sudo tar -xzvf l_onemklbench_p_2023.2.0_49340.tgz; mv benchmarks_2023.2.0//linux/mkl/benchmarks/linpack linpack
 # linpack-install-man
 
 # Newer linpack

--- a/docker/workload/Dockerfile-ubuntu_cb_nullworkload
+++ b/docker/workload/Dockerfile-ubuntu_cb_nullworkload
@@ -82,7 +82,8 @@ RUN apt-get install -y lftp iputils-ping
 
 # haproxy-install-pm
 RUN apt-get install -y software-properties-common
-RUN add-apt-repository -y ppa:vbernat/haproxy-2.0
+# haproxy 2.4 is now in ubuntu 22.04. PPA no longer available.
+# RUN add-apt-repository -y ppa:vbernat/haproxy-2.0
 RUN apt-get update
 RUN apt-get install -y haproxy
 # service_stop_disable haproxy

--- a/docker/workload/Dockerfile-ubuntu_cb_open_daytrader
+++ b/docker/workload/Dockerfile-ubuntu_cb_open_daytrader
@@ -32,7 +32,7 @@ RUN apt-get install -y apache2
 
 # mysql-install-pm
 RUN apt-get update; echo "mysql-server-5.7 mysql-server/root_password password temp4now" | sudo debconf-set-selections; echo "mysql-server-5.7 mysql-server/root_password_again password temp4now" | sudo debconf-set-selections
-RUN apt-get install -y ant unzip mysql-server python-mysqldb python-pip python-dev libmysqlclient-dev
+RUN apt-get install -y ant unzip mysql-server python3-mysqldb python3-pip python3-dev libmysqlclient-dev
 # mysql-install-pm
 
 # daytrader-install-man

--- a/docker/workload/Dockerfile-ubuntu_cb_tpcc
+++ b/docker/workload/Dockerfile-ubuntu_cb_tpcc
@@ -15,6 +15,9 @@ RUN apt-get install -y lsb-release
 RUN lsb_release -sc
 RUN wget https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
 RUN sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+# Percona has stopped building this package after 20.04. It is not available in 22.04 yet:
+# https://github.com/Percona-Lab/sysbench-tpcc/issues/50
+# Do we build it ourselves?
 RUN apt-get update; apt-get install -y sysbench sysbench-tpcc
 # sysbench-ARCHx86_64-install-pm
 

--- a/docker/workload/Dockerfile-ubuntu_cb_ycsb
+++ b/docker/workload/Dockerfile-ubuntu_cb_ycsb
@@ -7,19 +7,19 @@ RUN sudo apt --fix-broken -y install
 
 # cassandra-install-man
 RUN wget -N -v -P /home/REPLACE_USERNAME http://launchpadlibrarian.net/109052632/python-support_1.0.15_all.deb; dpkg -i /home/REPLACE_USERNAME/python-support*.deb; sudo apt --fix-broken -y install
-RUN wget -N -v -P /home/REPLACE_USERNAME http://dl.bintray.com/apache/cassandra/pool/main/c/cassandra/cassandra_2.1.20_all.deb 
+RUN wget -N -v -P /home/REPLACE_USERNAME https://mirrors.ibiblio.org/apache/cassandra/2.1.22/debian/cassandra_2.1.22_all.deb
 RUN dpkg -i /home/REPLACE_USERNAME/cassandra*.deb; sudo apt --fix-broken -y install
 # cassandra-install-man
 
 # cassandra-tools-install-man
-RUN wget -N -v -P /home/REPLACE_USERNAME http://dl.bintray.com/apache/cassandra/pool/main/c/cassandra/cassandra-tools_2.1.20_all.deb 
+RUN wget -N -v -P /home/REPLACE_USERNAME https://mirrors.ibiblio.org/apache/cassandra/2.1.22/debian/cassandra-tools_2.1.22_all.deb 
 RUN dpkg -i /home/REPLACE_USERNAME/cassandra-tools*.deb; sudo apt --fix-broken -y install
 # service_stop_disable cassandra
 # cassandra-tools-install-man
 
 # mongo-install-pm
-RUN apt-get install -y mongodb
-RUN sed -i "s/.*bind_ip.*/bind_ip=0.0.0.0/" /etc/mongodb.conf
+RUN wget -nc https://www.mongodb.org/static/pgp/server-6.0.asc; cat server-6.0.asc | gpg --dearmor | sudo tee /etc/apt/keyrings/mongodb.gpg >/dev/null; sudo sh -c 'echo "deb [ arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb.gpg] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" >> /etc/apt/sources.list.d/mongo.list'; sudo apt update; sudo apt install -y mongodb-org
+RUN sed -i "s/.*bind_ip.*/bind_ip=0.0.0.0/" /etc/mongod.conf
 # service_stop_disable mongodb
 # mongo-install-pm
 

--- a/scripts/linpack/cb_run_linpack.sh
+++ b/scripts/linpack/cb_run_linpack.sh
@@ -141,7 +141,7 @@ if [[ $LINPACK_VERSION == "2.3" ]]; then
         $(common_metrics)
 else
 	# Older Linpack
-	LINPACK=`get_my_ai_attribute_with_default linpack ~/compilers_and_libraries_2016.0.038/linux/mkl/benchmarks/linpack/xlinpack_xeon64`
+	LINPACK=`get_my_ai_attribute_with_default linpack ~/linpack/xlinpack_xeon64`
 	eval LINPACK=${LINPACK}
 
 	sudo ls ${LINPACK} 2>&1 > /dev/null


### PR DESCRIPTION
Not all workloads are 22.04 (Jammy) compatible:

1. sysbench-tpcc support stopped at 20.04.
2. mongodb was removed as a native Ubuntu package and requires using the company's PPA
3. We are still pinning cassandra for SPEC Cloud purposes. Is that still necessary given the current state of SPEC Cloud development?
4. The linpack URL changed yet again.
5. python2.7 was still being used in some places. We need to finish deprecating that.
6. Add a workload dockerfile for stress-ng. (I thought I did that already, but I guess not)