### PR TITLE
Libcloud support for Linode merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Each individual application can have a specific load profile using probability d
 2. OpenStack (and RackSpace)
 3. Google Compute Engine 
 4. DigitalOcean
-5. Linode (Akamai Connected Cloud)
+5. Linode (Akamai Connected Cloud), NOTE: libcloud version 3.9.0 only: https://github.com/apache/libcloud/pull/1946
 5. Docker/Swarm
 6. LXD/LXC
 7. Kubernetes

--- a/lib/clouds/lin_cloud_ops.py
+++ b/lib/clouds/lin_cloud_ops.py
@@ -102,8 +102,7 @@ class LinCmds(LibcloudCmds) :
             self.vmcreate_kwargs["ex_authorized_keys"] = public_keys
 
             if obj_attr_list["userdata"] not in (False, None) :
-                userdata = base64.b64encode(bytes(obj_attr_list["userdata"], 'utf-8'))
-                self.vmcreate_kwargs["ex_userdata"] = userdata.decode('utf-8')
+                self.vmcreate_kwargs["ex_userdata"] = obj_attr_list["userdata"]
 
         # The linode API really, really wants a root password,
         # so just give them a random one.


### PR DESCRIPTION
1. Merged: https://github.com/apache/libcloud/pull/1946 (This will likely go into version 3.9.0, based on their current release schedule)
2. The use of metadata changed, so make cloudbench change accordingly.