### PR TITLE
Fix Nutanix CreateVM and DeleteVM Functions for Insentive Workload of…

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,14 @@ Each individual application can have a specific load profile using probability d
 3. Google Compute Engine 
 4. DigitalOcean
 5. Linode (Akamai Connected Cloud), NOTE: libcloud version 3.9.0 only: https://github.com/apache/libcloud/pull/1946
-5. Docker/Swarm
-6. LXD/LXC
-7. Kubernetes
-8. Libvirt+KVM
-9. VMWare vCloud (NOT actively maintained)
-10. CloudStack (NOT actively maintained)
-11. SoftLayer
+6. Docker/Swarm
+7. LXD/LXC
+8. Kubernetes
+9. Libvirt+KVM
+10. VMWare vCloud (NOT actively maintained)
+11. CloudStack (NOT actively maintained)
+12. SoftLayer
+13. Nutanix
 
 Want to add support for a new Cloud? Take a look at our [Frequently Asked Questions](https://github.com/ibmcb/cbtool/wiki/FAQ#development-)
 

--- a/configs/cloud_definitions.txt
+++ b/configs/cloud_definitions.txt
@@ -24,6 +24,7 @@ CLOUDOPTION_MYEC2 = cldattach ec2, vmcattach all
 CLOUDOPTION_MYGCE = cldattach gce, vmcattach all
 CLOUDOPTION_MYKUB = cldattach kub, vmcattach all
 CLOUDOPTION_MYNOP = cldattach nop, vmcattach all
+CLOUDOPTION_MYNTNX = cldattach ntnx, vmcattach all
 CLOUDOPTION_MYOS = cldattach os, vmcattach all
 CLOUDOPTION_MYOSK = cldattach osk, vmcattach all
 CLOUDOPTION_MYPCM = cldattach pcm, vmcattach all
@@ -32,7 +33,6 @@ CLOUDOPTION_MYPLM = cldattach plm, vmcattach all
 CLOUDOPTION_MYSIM = cldattach sim, vmcattach all
 CLOUDOPTION_MYSLR = cldattach slr, vmcattach all
 CLOUDOPTION_MYVCD = cldattach vcd, vmcattach all
-CLOUDOPTION_MYZSTACK = cldattach zsk, vmcattach all
 
 # START: Specify the individual parameters for each cloud
 #-------------------------------------------------------------------------------
@@ -206,6 +206,22 @@ LIN_SSH_KEY_NAME = cbtool_rsa                                                   
 LIN_KEY_NAME = cbtool_rsa                                                                        # Comma-separated list of IDs (or names) of your Linode ssh keys
 LIN_NETNAME = default                                                                            # If your Orchestrator is running inside the cloud, use "private". If external to the cloud, use "public".For more complex networks, refer to the documentation
 LIN_LOGIN = cbuser                                                                               # The username that logins on the VMs
+
+#-------------------------------------------------------------------------------
+# Nunanix (ntnx) requires the following parameters 
+[USER-DEFINED : CLOUDOPTION_MYNTNX]
+NTNX_ACCESS = 10.80.30.20
+NTNX_CREDENTIALS =  username-password-default			# username-password-tenant
+NTNX_INITIAL_VMCS = RegionOne
+NTNX_SECURITY_GROUPS = default	   # Make sure that this group exists first
+NTNX_NETNAME = ss1111                                                                                                 # Make sure that this network exists first
+NTNX_SSH_KEY_NAME = cbtool_rsa                                                                                         # Name of the private/public key pair - locally available - used to login on the VMs
+NTNX_KEY_NAME = cbtool_rsa                                                                                             # Name of the private key present in the cloud to be injected on VMs
+NTNX_LOGIN = cbuser                                                                                                    # The username that logins on the VMs
+#-------------------------------------------------------------------------------
+
+
+
 
 [OBJECTSTORE]
 USAGE = shared


### PR DESCRIPTION
… Creation and Deletion

Some APIs of ntnx_api.prism on VMs (search_name, get, delete_name) does not work for insentive creation and deletion of VMs (instances). Replace these functions with RestAPI calls using the python 'requests' object.