### PR TITLE
convert the byte arrays to strings using UTF-8 encoding

### DIFF
--- a/lib/stores/mysql_datastore_adapter.py
+++ b/lib/stores/mysql_datastore_adapter.py
@@ -163,7 +163,7 @@ class MysqlMgdConn(MetricStoreMgdConn) :
             _tables_found = [] 
 
             for x in cursor:
-              _tables_found.append(x[0])
+              _tables_found.append(x[0].decode('utf-8'))
 
             for _table in (_latest_tables + _indexed_tables) :
                 if _table not in _tables_found :


### PR DESCRIPTION
In recent tests we noticed that the tables names are being returned as byte arrays in python3 while `_latest_tables` and `_indexed_tables` contains regular strings, which leads to the failure of finding table correctly. 
For instance, `latest_management_VM_username` is shown as `bytearray(b'latest_management_VM_username')` in `_tables_found`. 

Convert the byte arrays to regular strings using UTF-8. 
