### PR TITLE
Add try/except for using .decode attribute

### DIFF
--- a/lib/stores/mysql_datastore_adapter.py
+++ b/lib/stores/mysql_datastore_adapter.py
@@ -163,7 +163,12 @@ class MysqlMgdConn(MetricStoreMgdConn) :
             _tables_found = [] 
 
             for x in cursor:
-              _tables_found.append(x[0].decode('utf-8'))
+              try:
+                table_name = x[0].decode('utf-8')
+              except AttributeError:
+                table_name = x[0]
+
+              _tables_found.append(table_name)
 
             for _table in (_latest_tables + _indexed_tables) :
                 if _table not in _tables_found :


### PR DESCRIPTION
@mraygalaxy @mraygalaxy2  
A follow up PR for https://github.com/ibmcb/cbtool/pull/434
We also noticed in some other cases, the table names returned during cloudbench initialization were still regular strings. So use `try/except` to attempt to decode the table name `x[0]`. If it hits an `AttributeError`, then use the original `x[0]` instead. 